### PR TITLE
Fix Claude CLI tab background

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -104,7 +104,6 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         fgColor = new Color(display, fgR, fgG, fgB);
 
         parentComposite = parent;
-        parent.setBackground(bgColor);
         parent.setData("org.eclipse.e4.ui.css.disabled", Boolean.TRUE);
 
         Composite container = new Composite(parent, SWT.NONE);
@@ -114,12 +113,10 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         layout.marginHeight = 0;
         layout.verticalSpacing = 0;
         container.setLayout(layout);
-        container.setBackground(bgColor);
         container.setData("org.eclipse.e4.ui.css.disabled", Boolean.TRUE);
 
         tabFolder = new CTabFolder(container, SWT.BORDER | SWT.CLOSE);
         tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-        tabFolder.setSimple(false);
         tabFolder.setTabHeight(24);
 
         ToolBar toolbar = new ToolBar(tabFolder, SWT.FLAT);
@@ -246,14 +243,6 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         Color oldFg = fgColor;
         bgColor = new Color(display, bgR, bgG, bgB);
         fgColor = new Color(display, fgR, fgG, fgB);
-
-        // Update container backgrounds
-        if (parentComposite != null && !parentComposite.isDisposed()) {
-            parentComposite.setBackground(bgColor);
-        }
-        if (containerComposite != null && !containerComposite.isDisposed()) {
-            containerComposite.setBackground(bgColor);
-        }
 
         // Update all terminal sessions
         for (CTabItem item : tabFolder.getItems()) {


### PR DESCRIPTION
This also makes Claude CLI look more consistent with other Eclipse Views (e.g. Terminal)

Before change:
<img width="756" height="530" alt="1_before" src="https://github.com/user-attachments/assets/dd5a3d1e-a692-4bc2-8ae2-5336a0091250" />

After change:
<img width="755" height="531" alt="2_after" src="https://github.com/user-attachments/assets/fc68f4fa-5129-4120-9187-9bc2fca2e4be" />



Terminal View (for reference):
<img width="624" height="530" alt="3_terminal_example" src="https://github.com/user-attachments/assets/54ded87e-3f27-4d50-b965-433842019e18" />

Platform: KUbuntu 24.04
