### PR TITLE
Make StyledText read-only for Claude CLI view

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -469,7 +469,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         private void initPtyTerminal() {
             consoleHost.setLayout(new FillLayout());
 
-            termText = new StyledText(consoleHost, SWT.MULTI | SWT.V_SCROLL);
+            termText = new StyledText(consoleHost, SWT.MULTI | SWT.V_SCROLL | SWT.READ_ONLY);
             termText.setBackground(bgColor);
             // Use cachedColor so the Color object stays alive for the session.
             // StyledTextRenderer stores the Color reference internally; disposing it


### PR DESCRIPTION
In some scenarios it becomes possible to modify text on the StyledText directly, that breaks its layout:
<img width="755" height="429" alt="1_before" src="https://github.com/user-attachments/assets/f8374e26-5d46-4fba-900b-1d2c6607c712" />
