### PR TITLE
Fixed Exception during Eclipse Termination

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Activator.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Activator.java
@@ -3,6 +3,12 @@ package com.anthropic.claudecode.eclipse;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.IViewPart;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchListener;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -10,6 +16,7 @@ import com.anthropic.claudecode.eclipse.editor.SelectionTracker;
 import com.anthropic.claudecode.eclipse.mcp.McpToolRegistry;
 import com.anthropic.claudecode.eclipse.server.HttpSseServer;
 import com.anthropic.claudecode.eclipse.server.LockFileManager;
+import com.anthropic.claudecode.eclipse.ui.ClaudeCliView;
 
 public class Activator extends AbstractUIPlugin {
 
@@ -20,6 +27,7 @@ public class Activator extends AbstractUIPlugin {
     private McpToolRegistry toolRegistry;
     private SelectionTracker selectionTracker;
     private LockFileManager lockFileManager;
+    private IWorkbenchListener workbenchShutdownListener;
 
     @Override
     public void start(BundleContext context) throws Exception {
@@ -78,9 +86,39 @@ public class Activator extends AbstractUIPlugin {
         }
 
         LOG.info("Claude Code server started on port " + port);
+
+        if (workbenchShutdownListener == null && PlatformUI.isWorkbenchRunning()) {
+            workbenchShutdownListener = new IWorkbenchListener() {
+                @Override
+                public boolean preShutdown(IWorkbench workbench, boolean forced) {
+                    disconnectAllTerminals(workbench);
+                    return true;
+                }
+                @Override
+                public void postShutdown(IWorkbench workbench) {}
+            };
+            PlatformUI.getWorkbench().addWorkbenchListener(workbenchShutdownListener);
+        }
+    }
+
+    private void disconnectAllTerminals(IWorkbench workbench) {
+        for (IWorkbenchWindow window : workbench.getWorkbenchWindows()) {
+            for (IWorkbenchPage page : window.getPages()) {
+                IViewPart view = page.findView(ClaudeCliView.VIEW_ID);
+                if (view instanceof ClaudeCliView) {
+                    ((ClaudeCliView) view).disconnectAllSessions();
+                }
+            }
+        }
     }
 
     public void shutdown() {
+        if (workbenchShutdownListener != null) {
+            if (PlatformUI.isWorkbenchRunning()) {
+                PlatformUI.getWorkbench().removeWorkbenchListener(workbenchShutdownListener);
+            }
+            workbenchShutdownListener = null;
+        }
         if (selectionTracker != null) {
             selectionTracker.stop();
             selectionTracker = null;

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -349,6 +349,14 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         return false;
     }
 
+    public void disconnectAllSessions() {
+        if (tabFolder == null || tabFolder.isDisposed()) return;
+        for (CTabItem item : tabFolder.getItems()) {
+            TerminalSession session = (TerminalSession) item.getData();
+            if (session != null) session.disconnect();
+        }
+    }
+
     @Override
     public void dispose() {
         viewDisposed = true;
@@ -659,6 +667,13 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             if (prefStore != null) {
                 setPrefColor(prefStore, TerminalColor.FOREGROUND, fgR, fgG, fgB);
                 setPrefColor(prefStore, TerminalColor.BACKGROUND, bgR, bgG, bgB);
+            }
+        }
+
+        void disconnect() {
+            if (termControl != null && !termControl.isDisposed()
+                    && termControl.getState() != TerminalState.CLOSED) {
+                termControl.disconnectTerminal();
             }
         }
 


### PR DESCRIPTION
The following exception is printed into Eclipse Console during termination from time to time:
```
  !ENTRY org.eclipse.core.jobs 2 2 2026-06-03 22:58:21.631
  !MESSAGE Job found still running after platform shutdown.  Jobs should be canceled by the plugin that scheduled them during shutdown: org.eclipse.terminal.internal.emulator.VT100TerminalControl$1
  RUNNING
       at java.base/java.lang.Object.wait0(Native Method)
       at java.base/java.lang.Object.wait(Object.java:366)
       at org.eclipse.terminal.internal.textcanvas.PipedInputStream.waitForAvailable(PipedInputStream.java:265) 
       at org.eclipse.terminal.internal.emulator.VT100TerminalControl$1.run(VT100TerminalControl.java:489)
       at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

## The reason
The `VT100TerminalControl$1` job is the "Terminal data reader" job started by `connectTerminal()`. It loops, blocking on `PipedInputStream.waitForAvailable(500)` while waiting for terminal output. It stops cleanly when `disconnectTerminal()` is called (which cancels the job, interrupts its thread, and joins it).

The job _is_ stopped in `TerminalSession.dispose()` → `termControl.disposeTerminal()` → `disconnectTerminal()`. The bug is timing: the Eclipse platform job manager's shutdown check runs before the workbench has closed views and called `dispose()`. Views are disposed as part of workbench window closing, which can happen after the platform runtime's job manager has already performed its still-running check.

## The fix
Register an `IWorkbenchListener` whose `preShutdown()` callback explicitly disconnects all active terminal sessions. `preShutdown()` fires before the workbench begins closing windows/views, which is before the platform runtime shuts down its job manager. This ensures the reader jobs are cancelled and joined before the platform checks for them.
