### PR TITLE
Added action to quickly activate Claude CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Go to **Window → Show View → Other → Claude Code** and open the views you 
 | Shortcut | Action |
 |---|---|
 | `Ctrl+Shift+C` | Toggle Claude Code view |
+| ``Ctrl+` ``    | Activate Claude CLI view |
 | `Ctrl+Shift+S` | Send current editor selection to Claude |
 | `Ctrl+Alt+A` | Add current file to Claude's context |
 

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -63,6 +63,11 @@
             name="Restart Claude Code Server"
             description="Restart the MCP server"
             categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
+      <command
+            id="com.anthropic.claudecode.eclipse.commands.activateCli"
+            name="Activate Claude CLI"
+            description="Open the Claude CLI view"
+            categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
    </extension>
 
    <!-- Command Handlers -->
@@ -82,6 +87,9 @@
       <handler
             commandId="com.anthropic.claudecode.eclipse.commands.restart"
             class="com.anthropic.claudecode.eclipse.ui.handlers.RestartServerHandler"/>
+      <handler
+            commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
+            class="com.anthropic.claudecode.eclipse.ui.handlers.ActivateClaudeCliHandler"/>
    </extension>
 
    <!-- Key Bindings -->
@@ -98,6 +106,10 @@
             commandId="com.anthropic.claudecode.eclipse.commands.addFile"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M3+A"/>
+      <key
+            commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+`"/>
    </extension>
 
    <!-- Menus and Toolbar -->
@@ -112,6 +124,11 @@
                   commandId="com.anthropic.claudecode.eclipse.commands.toggle"
                   label="Toggle Claude Code"
                   mnemonic="T"
+                  style="push"/>
+            <command
+                  commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
+                  label="Activate Claude CLI"
+                  mnemonic="L"
                   style="push"/>
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.sendSelection"

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -177,7 +177,7 @@
                   icon="icons/claude-16.png"
                   label="Toggle Claude Code"
                   style="push"
-                  tooltip="Toggle Claude Code (Ctrl+Shift+C)"/>
+                  tooltip="Toggle Claude Code"/>
          </toolbar>
       </menuContribution>
    </extension>

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -173,11 +173,11 @@
       <menuContribution locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
          <toolbar id="com.anthropic.claudecode.eclipse.toolbar">
             <command
-                  commandId="com.anthropic.claudecode.eclipse.commands.toggle"
+                  commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
                   icon="icons/claude-16.png"
-                  label="Toggle Claude Code"
+                  label="Activate Claude CLI"
                   style="push"
-                  tooltip="Toggle Claude Code"/>
+                  tooltip="Activate Claude CLI"/>
          </toolbar>
       </menuContribution>
    </extension>

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -296,6 +296,11 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         openNewSession(cwd, scopeLabel, extraArgs);
     }
 
+    public void ensureAtLeastOneTab() {
+        if (tabFolder == null || tabFolder.isDisposed()) return;
+        if (tabFolder.getItemCount() == 0) openNewSession(null, null);
+    }
+
     public void restartAllSessions() {
         if (tabFolder == null || tabFolder.isDisposed()) return;
         int count = tabFolder.getItemCount();

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/ActivateClaudeCliHandler.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/ActivateClaudeCliHandler.java
@@ -1,0 +1,30 @@
+package com.anthropic.claudecode.eclipse.ui.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import com.anthropic.claudecode.eclipse.Activator;
+import com.anthropic.claudecode.eclipse.ui.ClaudeCliView;
+
+public class ActivateClaudeCliHandler extends AbstractHandler {
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        try {
+            IWorkbenchPage page = HandlerUtil.getActiveWorkbenchWindow(event).getActivePage();
+            if (page == null) return null;
+
+            if (!Activator.getDefault().isServerRunning()) {
+                Activator.getDefault().initialize();
+            }
+            ClaudeCliView view = (ClaudeCliView) page.showView(ClaudeCliView.VIEW_ID);
+            if (view != null) view.ensureAtLeastOneTab();
+        } catch (Exception e) {
+            Activator.logError("Failed to activate Claude CLI view", e);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
It would be convenient to quickly jump to Claude CLI from any other Editor/View to communicate with Claude Code. This PR implements this.

Also this PR changes action button on the main toolbar. The reason: a user will probably more often needs to open Claude CLI view to communicate with Claude Code than to check Server status (taking into account it starts automatically).
Some day we may have both actions on the toolbar, but we need different icons for them.

Also removed shortcut text from tooltip of the action on main toolbar, as it is automatically added by Eclipse itself. Moreover it may become outdated if shortcut is changed in preferences. 
Before:
<img width="305" height="64" alt="toolbar_tooltip" src="https://github.com/user-attachments/assets/1f78b68f-3449-436d-8581-9033bd5b8397" />
