### PR TITLE
Change conflicting Ctrl+Shift+S shortcut to Ctrl+Alt+S

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Go to **Window → Show View → Other → Claude Code** and open the views you 
 |---|---|
 | `Ctrl+Shift+C` | Toggle Claude Code view |
 | ``Ctrl+` ``    | Activate Claude CLI view |
-| `Ctrl+Shift+S` | Send current editor selection to Claude |
+| `Ctrl+Alt+S` | Send current editor selection to Claude |
 | `Ctrl+Alt+A` | Add current file to Claude's context |
 
 These are also available from the **Claude Code** menu in the menu bar and from the right-click context menu in any text editor.

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -101,7 +101,7 @@
       <key
             commandId="com.anthropic.claudecode.eclipse.commands.sendSelection"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M1+M2+S"/>
+            sequence="M1+M3+S"/>
       <key
             commandId="com.anthropic.claudecode.eclipse.commands.addFile"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"


### PR DESCRIPTION
Re-applies PR #30 from xgsa. On Linux, Ctrl+Shift+S is mapped to Save All, so using Ctrl+Alt+S instead.