### PR TITLE
Replace internal CompareEditor with public API in AcceptDiffTool

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/tools/AcceptDiffTool.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/tools/AcceptDiffTool.java
@@ -3,7 +3,6 @@ package com.anthropic.claudecode.eclipse.tools;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.eclipse.compare.internal.CompareEditor;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
@@ -15,7 +14,6 @@ import com.anthropic.claudecode.eclipse.mcp.McpTool;
 import com.anthropic.claudecode.eclipse.mcp.McpToolResult;
 import com.google.gson.JsonObject;
 
-@SuppressWarnings("restriction")
 public class AcceptDiffTool implements McpTool {
 
     @Override
@@ -88,7 +86,7 @@ public class AcceptDiffTool implements McpTool {
 
         for (IEditorReference ref : page.getEditorReferences()) {
             var editor = ref.getEditor(false);
-            if (editor instanceof CompareEditor && editor.getEditorInput() == entry.getEditorInput()) {
+            if (editor.getEditorInput() == entry.getEditorInput()) {
                 page.closeEditor(editor, false);
                 break;
             }


### PR DESCRIPTION
While I was working on another feature, Claude Code advised me this fix and it sounds reasonable, thus I have extracted it into a separate PR, so it can be easily applied or dropped (I'd voted for applying if there is no strong reason to use internal API):
> The editor lookup used org.eclipse.compare.internal.CompareEditor for an instanceof check, requiring @SuppressWarnings("restriction"). Since each DiffEntry holds a unique CompareEditorInput instance (public API), matching on editor input identity is sufficient and avoids the internal dependency.