### PR TITLE
Add one-time Ctrl+Click hint bar to Claude CLI view

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -21,6 +21,9 @@ public final class Constants {
     public static final String PREF_AUTO_LAUNCH_CLI = "autoLaunchCli";
     public static final String PREF_DEBUG_MODE = "debugMode";
 
+    /** Set once the user dismisses the Ctrl+Click hint bar in the Claude CLI view (per-workspace). */
+    public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
+
     public static final String PREF_HTTP_PROXY = "httpProxy";
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/resolvers/EntitiesRegistry.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/resolvers/EntitiesRegistry.java
@@ -67,6 +67,21 @@ public class EntitiesRegistry {
 		return result;
 	}
 	
+	/**
+	 * The display names of the registered resolvers, in registration order (e.g. for a hint that
+	 * enumerates the recognizable entity kinds). Reflects the JDT-optional gating: the Java resolver's
+	 * name is only present when {@link #addJavaResolverIfAvailable()} actually registered it.
+	 *
+	 * @see IEntityResolver#getName()
+	 */
+	public List<String> getResolverNames() {
+		List<String> names = new ArrayList<>();
+		for (IEntityResolver resolver : resolvers) {
+			names.add(resolver.getName());
+		}
+		return names;
+	}
+
 	private void addResolver(IEntityResolver resolver) {
 		resolvers.add(resolver);
 	}

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -39,7 +39,10 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.IShowInTarget;
@@ -140,6 +143,9 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
         tabFolder.setTabHeight(24);
 
+        // Bottom hint bar (shown once per workspace) advertising Ctrl+Click navigation.
+        showCtrlClickHintIfNeeded(container);
+
         configureActionBars();
 
         tabFolder.addCTabFolder2Listener(new CTabFolder2Adapter() {
@@ -202,6 +208,58 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             if (session != null) session.updateTheme();
         }
         if (oldBg != null && !oldBg.isDisposed()) oldBg.dispose();
+    }
+
+    private static String getModKey() {
+        return Activator.isMacOS() ? "\u2318" : "Ctrl";
+    }
+
+    /**
+     * Builds the one-time hint bar at the bottom of {@code container}, advertising the
+     * (otherwise invisible) Ctrl+Click (Cmd+Click on macOS) - entity navigation and enumerating the
+     * recognizable entity kinds. Does nothing once the user has dismissed it in this workspace
+     * ({@link Constants#PREF_CLI_CTRLCLICK_HINT_DISMISSED}).
+     */
+    private void showCtrlClickHintIfNeeded(Composite container) {
+        if (Activator.getDefault().getPreferenceStore().getBoolean(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED)) {
+            return;
+        }
+        Display display = container.getDisplay();
+        Color infoBg = display.getSystemColor(SWT.COLOR_INFO_BACKGROUND);
+        Color infoFg = display.getSystemColor(SWT.COLOR_INFO_FOREGROUND);
+
+        final Composite hintBanner = new Composite(container, SWT.NONE);
+        hintBanner.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+        hintBanner.setBackground(infoBg);
+        GridLayout bannerLayout = new GridLayout(3, false);
+        bannerLayout.marginHeight = 3;
+        bannerLayout.marginWidth = 5;
+        hintBanner.setLayout(bannerLayout);
+
+        ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
+
+        String kinds = String.join(", ", entitiesRegistry.getResolverNames());
+        Label message = new Label(hintBanner, SWT.WRAP);
+        message.setBackground(infoBg);
+        message.setForeground(infoFg);
+        message.setText("✨ Tip: hold " + getModKey() + " and click on " + kinds + " in the output to open it");
+        message.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+
+        ToolBar closeBar = new ToolBar(hintBanner, SWT.FLAT);
+        closeBar.setBackground(infoBg);
+        closeBar.setLayoutData(new GridData(SWT.END, SWT.CENTER, false, false));
+        ToolItem closeItem = new ToolItem(closeBar, SWT.PUSH);
+        closeItem.setImage(sharedImages.getImage(ISharedImages.IMG_ELCL_REMOVE));
+        closeItem.setToolTipText("Dismiss");
+        closeItem.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> {
+			Activator.getDefault().getPreferenceStore()
+			        .setValue(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, true);
+			if (hintBanner != null && !hintBanner.isDisposed()) {
+			    Composite parent = hintBanner.getParent();
+			    hintBanner.dispose();
+			    if (parent != null && !parent.isDisposed()) parent.layout(true, true);
+			}
+		}));
     }
 
     private void configureActionBars() {
@@ -732,7 +790,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             Control canvas = control.getControl();
             if (canvas == null || canvas.isDisposed()) return;
 
-			String modKey = Activator.isMacOS() ? "\u2318" : "Ctrl";
+			String modKey = getModKey();
 			MenuManager mgr = new MenuManager();
             ISharedImages sharedImages = PlatformUI.getWorkbench().getSharedImages();
             DisablingAction openAction = new DisablingAction("&Open", null, null) {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -23,6 +23,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_TERMINAL_POSITION, "bottom");
         store.setDefault(Constants.PREF_AUTO_LAUNCH_CLI, false);
         store.setDefault(Constants.PREF_DEBUG_MODE, false);
+        store.setDefault(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, false);
 
         store.setDefault(Constants.PREF_HTTP_PROXY, "");
         store.setDefault(Constants.PREF_HTTPS_PROXY, "");


### PR DESCRIPTION
The Ctrl/Cmd+Click entity navigation in the CLI terminal output was invisible to users. Show a dismissable info bar at the bottom of the view explaining the gesture and enumerating the recognizable entity kinds.

Dismissal is persisted per-workspace (PREF_CLI_CTRLCLICK_HINT_DISMISSED), so the bar never reappears once closed.

Here is how it looks like:
<img width="810" height="288" alt="2_breadcrumb_scr" src="https://github.com/user-attachments/assets/431b6c76-529f-41fa-8cf5-a7715bec1044" />
_(note: the typo "Java Indentifier" has already been fixed in #53)_