### PR TITLE
Auto-derive Claude CLI light/dark hint from terminal background

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Go to **Window → Show View → Other → Claude Code** and open the views you 
 
 > **Font customization (all platforms):** The console font can be changed in **Window → Preferences → General → Appearance → Colors and Fonts → Basic → Claude CLI Console Font**. By default it inherits from Eclipse's "Text Font" setting. **Linux users:** If you see horizontal lines or other rendering artifacts, try setting the font to one commonly used by terminal emulators (e.g., MesloLGS NF, JetBrains Mono, or your terminal's default font).
 
-> **Color customization (all platforms):** The Claude CLI's background/foreground colors — and the Dark/Light theme hint — can be set in **Window → Preferences → Claude Code** ("Claude CLI background", "Claude CLI foreground", and "Claude CLI theme"). These are independent of Eclipse's built-in Terminal colors and apply immediately without restart.
+> **Color customization (all platforms):** The Claude CLI's background/foreground colors — can be set in **Window → Preferences → Claude Code** ("Claude CLI background" and "Claude CLI foreground"). These are independent of Eclipse's built-in Terminal colors and apply immediately without restart.
 
 ### Keyboard Shortcuts
 
@@ -139,7 +139,6 @@ Go to **Window → Preferences → Claude Code** to configure:
 | Claude command | `claude` | Path to the Claude CLI executable |
 | Arguments | *(empty)* | Additional CLI arguments (e.g., `--model claude-opus-4-7-20260418`) |
 | Port range (min/max) | 10000–65535 | Port range for the internal HTTP+SSE server |
-| Claude CLI theme | Dark | Theme hint for Claude's `/theme auto` (Dark or Light); applies immediately |
 | Claude CLI background / foreground | `#121314` / `#E5E5E5` | Terminal colors, independent of Eclipse's Terminal; apply immediately |
 
 ## Architecture

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -28,10 +28,6 @@ public final class Constants {
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";
 
-    public static final String PREF_CONSOLE_THEME = "consoleTheme";
-    public static final String CONSOLE_THEME_DARK = "dark";
-    public static final String CONSOLE_THEME_LIGHT = "light";
-
     /** Claude CLI terminal colors (independent of Eclipse's Terminal prefs).
      *  Stored as PreferenceConverter RGB strings ("r,g,b"). */
     public static final String PREF_CONSOLE_BG_COLOR = "consoleBgColor";

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -112,9 +112,11 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     private static final String LOCAL_CONNECTOR_ID =
             "org.eclipse.terminal.connector.local.LocalConnector";
 
-    // COLORFGBG hint for Claude's "/theme auto", derived from the console theme.
+    // COLORFGBG hint for Claude's "/theme auto", derived from the terminal background luminance.
     private static final String DARK_COLORFGBG_ENV_VAL = "15;0";
     private static final String LIGHT_COLORFGBG_ENV_VAL = "0;15";
+    // Perceived-luminance cutoff (of 255) below which the terminal background counts as dark.
+    private static final double DARK_BG_LUMINANCE_THRESHOLD = 128;
 
     // Active terminal colors, read from the PREF_CONSOLE_BG/FG_COLOR preferences
     // (user-configurable, independent of Eclipse's shared Terminal colors).
@@ -138,9 +140,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     public void createPartControl(Composite parent) {
         Display display = parent.getDisplay();
 
-        String theme = Activator.getDefault().getPreferenceStore()
-                .getString(Constants.PREF_CONSOLE_THEME);
-        setThemeColors(theme, display);
+        setThemeColors(display);
 
         Composite container = new Composite(parent, SWT.NONE);
         GridLayout layout = new GridLayout(1, false);
@@ -194,8 +194,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
 
         themeChangeListener = event -> {
             String p = event.getProperty();
-            if (Constants.PREF_CONSOLE_THEME.equals(p)
-                    || Constants.PREF_CONSOLE_BG_COLOR.equals(p)
+            if (Constants.PREF_CONSOLE_BG_COLOR.equals(p)
                     || Constants.PREF_CONSOLE_FG_COLOR.equals(p)) {
                 display.asyncExec(() -> {
                     if (viewDisposed || tabFolder == null || tabFolder.isDisposed()) return;
@@ -210,9 +209,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         Display display = Display.getCurrent();
         if (display == null) return;
         Color oldBg = bgColor;
-        String theme = Activator.getDefault().getPreferenceStore()
-                .getString(Constants.PREF_CONSOLE_THEME);
-        setThemeColors(theme, display);
+        setThemeColors(display);
         for (CTabItem item : tabFolder.getItems()) {
             TerminalSession session = (TerminalSession) item.getData();
             if (session != null) session.updateTheme();
@@ -333,9 +330,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         toolBar.add(scrollLockAction);
     }
 
-    private void setThemeColors(String theme, Display display) {
-        colorFgBgEnvVal = Constants.CONSOLE_THEME_LIGHT.equals(theme)
-                ? LIGHT_COLORFGBG_ENV_VAL : DARK_COLORFGBG_ENV_VAL;
+    private void setThemeColors(Display display) {
         // Background/foreground come from the user-configurable preferences.
         IPreferenceStore store = Activator.getDefault().getPreferenceStore();
         RGB bg = PreferenceConverter.getColor(store, Constants.PREF_CONSOLE_BG_COLOR);
@@ -343,6 +338,15 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         bgR = bg.red; bgG = bg.green; bgB = bg.blue;
         fgR = fg.red; fgG = fg.green; fgB = fg.blue;
         bgColor = new Color(display, bgR, bgG, bgB);
+
+        // COLORFGBG tells Claude's "/theme auto" whether its background is dark or light. We derive it
+        // from the actual configured terminal background (PREF_CONSOLE_BG_COLOR), not Eclipse's
+        // General > Appearance theme: that color is what is genuinely painted behind the terminal (and
+        // can differ from the SWT widget/theme color), so its luminance is the ground truth for the hint.
+        // This keeps it correct for any custom color and avoids the discouraged x-friends IThemeEngine
+        // (and its fragile theme-id matching, which mislabels light themes like "Classic").
+        colorFgBgEnvVal = ColorUtils.luminance(bg) < DARK_BG_LUMINANCE_THRESHOLD
+                ? DARK_COLORFGBG_ENV_VAL : LIGHT_COLORFGBG_ENV_VAL;
     }
 
     /**

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -29,8 +29,6 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_HTTPS_PROXY, "");
         store.setDefault(Constants.PREF_NO_PROXY, "");
 
-        store.setDefault(Constants.PREF_CONSOLE_THEME, Constants.CONSOLE_THEME_DARK);
-
         // Claude CLI status bar (statusLine) — on by default, except the thinking segment.
         store.setDefault(Constants.PREF_STATUSLINE_ENABLED, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_MODEL, true);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.ColorFieldEditor;
-import org.eclipse.jface.preference.ComboFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -78,15 +77,6 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         addField(new BooleanFieldEditor(
                 Constants.PREF_DEBUG_MODE,
                 "Debug mode",
-                getFieldEditorParent()));
-
-        addField(new ComboFieldEditor(
-                Constants.PREF_CONSOLE_THEME,
-                "Claude CLI theme:",
-                new String[][] {
-                    {"Dark", Constants.CONSOLE_THEME_DARK},
-                    {"Light", Constants.CONSOLE_THEME_LIGHT}
-                },
                 getFieldEditorParent()));
 
         // Claude CLI terminal colors — independent of Eclipse's Terminal colors.

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ColorUtils.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ColorUtils.java
@@ -1,0 +1,23 @@
+package com.anthropic.claudecode.eclipse.ui;
+
+import org.eclipse.swt.graphics.RGB;
+
+/** Small stateless color-math helpers. */
+public final class ColorUtils {
+
+    private ColorUtils() {}
+
+    /**
+     * Perceived (Rec. 601) luminance of an sRGB color, 0 (black)–255 (white).
+     * This is perceptual luminance, NOT HSB brightness ({@code RGB.getHSB()[2]}, which is
+     * {@code max(r,g,b)/255}) — the weighting reflects how bright each channel reads to the eye.
+     */
+    public static double luminance(int r, int g, int b) {
+        return r * 0.299 + g * 0.587 + b * 0.114;
+    }
+
+    /** {@link #luminance(int, int, int)} for an SWT {@link RGB}. */
+    public static double luminance(RGB rgb) {
+        return luminance(rgb.red, rgb.green, rgb.blue);
+    }
+}


### PR DESCRIPTION
Remove the dedicated "Claude CLI theme" dropdown (PREF_CONSOLE_THEME) and instead derive the COLORFGBG hint passed to Claude's "/theme auto" from the perceived luminance of the configured terminal background (PREF_CONSOLE_BG_COLOR). That color is what is actually painted behind the terminal, so its luminance is the ground truth for whether Claude should render a light or dark palette: self-consistent with what the user sees, correct for any custom color, and needing no theme API. A small reusable ColorUtils.luminance() helper is extracted for the math.

Alternatives considered (and rejected):
- Eclipse's active theme via IThemeEngine: x-friends (discouraged access), and its theme-id matching mislabels light themes like "Classic" (service can also be null during view init, defaulting to dark).
- Hardcoded "themeid" preference read: depends on internal, non-API node/key strings that would fail silently if the platform ever renames them.
- Workbench getThemeManager().getCurrentTheme(): modern Eclipse exposes a single constant "CssTheme" id that does not distinguish light from dark.
- Display.getSystemColor / isSystemDarkTheme: reflects the SWT widget or OS theme, which can differ from the terminal's own configured background.