### PR TITLE
Rename views to be more clear for a user and reordered the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ Set `ANTHROPIC_API_KEY` in your environment before launching Eclipse:
 ### Opening the Views
 
 Go to **Window → Show View → Other → Claude Code** and open the views you want:
-- **Claude Code** — server status, launch/resume/restart controls
-- **Claude Terminal** — dedicated interactive terminal (multiple "Claude N" tabs), built on the Eclipse Terminal with full ANSI/24-bit color, scrollback, copy/paste, customizable colors, and Ctrl/⌘-click navigation to file paths and links mentioned in Claude's answers
+- **Claude Terminal** — dedicated interactive terminal, built on the Eclipse Terminal with full ANSI/24-bit color, scrollback, copy/paste, customizable colors, and Ctrl/⌘-click navigation to file paths and links mentioned in Claude's answers
 - **Claude Chat** — web-based chat interface with markdown rendering
+- **Claude IDE Server** — server status, launch/resume/restart controls
+
 
 ### Getting Started
 
-1. In the **Claude Code** view, click **Launch Claude Terminal** — this opens the **Claude Terminal** view and starts Claude automatically
-2. Type directly in the **Claude Terminal** view, or switch to **Claude Chat** for a richer markdown interface
-3. Claude can read your open files, selection, and workspace context automatically via MCP tools
+1. Open the **Claude Terminal** view, or switch to **Claude Chat** for a richer markdown interface
+2. Claude can read your open files, selection, and workspace context automatically via MCP tools
 
 > **Note (all platforms):** The Claude Terminal view embeds the Eclipse Terminal control and launches `claude` over a local PTY (ConPTY on Windows, native PTY on Linux/macOS), with full ANSI/24-bit color, scrollback, and resize. Copy/paste is available via the right-click menu or the keyboard: `Ctrl/⌘+V` (or `Shift+Insert`) to paste, `Ctrl/⌘+Shift+C` to copy, and `Ctrl/⌘+C` copies when text is selected (otherwise it passes through to interrupt Claude).
 
@@ -97,7 +97,7 @@ Go to **Window → Show View → Other → Claude Code** and open the views you 
 
 | Shortcut | Action |
 |---|---|
-| `Ctrl+Shift+C` | Toggle Claude Code view |
+| `Ctrl+Shift+Alt+C` | Toggle Claude IDE Server view |
 | ``Ctrl+` ``    | Activate Claude Terminal view |
 | `Ctrl+Alt+S` | Send current editor selection to Claude |
 | `Ctrl+Alt+A` | Add current file to Claude's context |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ An Eclipse IDE plugin that integrates [Claude Code](https://claude.ai/code) — 
 
 ### Required Eclipse Terminal bundles
 
-The **Claude CLI** view embeds the Eclipse Terminal, so these bundles must be present (version **1.1.0 or newer**, within the `1.x` range):
+The **Claude Terminal** view embeds the Eclipse Terminal, so these bundles must be present (version **1.1.0 or newer**, within the `1.x` range):
 
 - `org.eclipse.terminal.control`
 - `org.eclipse.terminal.connector.process`
@@ -76,29 +76,29 @@ Set `ANTHROPIC_API_KEY` in your environment before launching Eclipse:
 
 Go to **Window → Show View → Other → Claude Code** and open the views you want:
 - **Claude Code** — server status, launch/resume/restart controls
-- **Claude CLI** — dedicated interactive terminal (multiple "Claude N" tabs), built on the Eclipse Terminal with full ANSI/24-bit color, scrollback, copy/paste, customizable colors, and Ctrl/⌘-click navigation to file paths and links mentioned in Claude's answers
+- **Claude Terminal** — dedicated interactive terminal (multiple "Claude N" tabs), built on the Eclipse Terminal with full ANSI/24-bit color, scrollback, copy/paste, customizable colors, and Ctrl/⌘-click navigation to file paths and links mentioned in Claude's answers
 - **Claude Chat** — web-based chat interface with markdown rendering
 
 ### Getting Started
 
-1. In the **Claude Code** view, click **Launch Claude Terminal** — this opens the **Claude CLI** view and starts Claude automatically
-2. Type directly in the **Claude CLI** view, or switch to **Claude Chat** for a richer markdown interface
+1. In the **Claude Code** view, click **Launch Claude Terminal** — this opens the **Claude Terminal** view and starts Claude automatically
+2. Type directly in the **Claude Terminal** view, or switch to **Claude Chat** for a richer markdown interface
 3. Claude can read your open files, selection, and workspace context automatically via MCP tools
 
-> **Note (all platforms):** The Claude CLI view embeds the Eclipse Terminal control and launches `claude` over a local PTY (ConPTY on Windows, native PTY on Linux/macOS), with full ANSI/24-bit color, scrollback, and resize. Copy/paste is available via the right-click menu or the keyboard: `Ctrl/⌘+V` (or `Shift+Insert`) to paste, `Ctrl/⌘+Shift+C` to copy, and `Ctrl/⌘+C` copies when text is selected (otherwise it passes through to interrupt Claude).
+> **Note (all platforms):** The Claude Terminal view embeds the Eclipse Terminal control and launches `claude` over a local PTY (ConPTY on Windows, native PTY on Linux/macOS), with full ANSI/24-bit color, scrollback, and resize. Copy/paste is available via the right-click menu or the keyboard: `Ctrl/⌘+V` (or `Shift+Insert`) to paste, `Ctrl/⌘+Shift+C` to copy, and `Ctrl/⌘+C` copies when text is selected (otherwise it passes through to interrupt Claude).
 
-> **Open files, links, and Java references:** Claude often references file paths, URLs and Java type/member names in its answers. **Ctrl-click** (⌘-click on macOS) any such token in the **Claude CLI** view to jump straight to it — a file opens in an editor, an `http`/`https` URL opens in your browser, and a Java reference (e.g. `java.util.List`, `com.foo.Bar:21`, `Bar#baz(int)`) opens in the Java editor (only if JDT is installed). Paths and file names containing spaces are fully supported — absolute or workspace-relative, even when the path wraps across terminal lines or a file name appears mid-sentence — clicking any segment opens the right file. You can also select text and choose **Open** from the right-click menu.
+> **Open files, links, and Java references:** Claude often references file paths, URLs and Java type/member names in its answers. **Ctrl-click** (⌘-click on macOS) any such token in the **Claude Terminal** view to jump straight to it — a file opens in an editor, an `http`/`https` URL opens in your browser, and a Java reference (e.g. `java.util.List`, `com.foo.Bar:21`, `Bar#baz(int)`) opens in the Java editor (only if JDT is installed). Paths and file names containing spaces are fully supported — absolute or workspace-relative, even when the path wraps across terminal lines or a file name appears mid-sentence — clicking any segment opens the right file. You can also select text and choose **Open** from the right-click menu.
 
-> **Font customization (all platforms):** The console font can be changed in **Window → Preferences → General → Appearance → Colors and Fonts → Basic → Claude CLI Console Font**. By default it inherits from Eclipse's "Text Font" setting. **Linux users:** If you see horizontal lines or other rendering artifacts, try setting the font to one commonly used by terminal emulators (e.g., MesloLGS NF, JetBrains Mono, or your terminal's default font).
+> **Font customization (all platforms):** The console font can be changed in **Window → Preferences → General → Appearance → Colors and Fonts → Basic → Claude Terminal Console Font**. By default it inherits from Eclipse's "Text Font" setting. **Linux users:** If you see horizontal lines or other rendering artifacts, try setting the font to one commonly used by terminal emulators (e.g., MesloLGS NF, JetBrains Mono, or your terminal's default font).
 
-> **Color customization (all platforms):** The Claude CLI's background/foreground colors — can be set in **Window → Preferences → Claude Code** ("Claude CLI background" and "Claude CLI foreground"). These are independent of Eclipse's built-in Terminal colors and apply immediately without restart.
+> **Color customization (all platforms):** The Claude Terminal's background/foreground colors — can be set in **Window → Preferences → Claude Code** ("Claude Terminal background" and "Claude Terminal foreground"). These are independent of Eclipse's built-in Terminal colors and apply immediately without restart.
 
 ### Keyboard Shortcuts
 
 | Shortcut | Action |
 |---|---|
 | `Ctrl+Shift+C` | Toggle Claude Code view |
-| ``Ctrl+` ``    | Activate Claude CLI view |
+| ``Ctrl+` ``    | Activate Claude Terminal view |
 | `Ctrl+Alt+S` | Send current editor selection to Claude |
 | `Ctrl+Alt+A` | Add current file to Claude's context |
 
@@ -139,7 +139,7 @@ Go to **Window → Preferences → Claude Code** to configure:
 | Claude command | `claude` | Path to the Claude CLI executable |
 | Arguments | *(empty)* | Additional CLI arguments (e.g., `--model claude-opus-4-7-20260418`) |
 | Port range (min/max) | 10000–65535 | Port range for the internal HTTP+SSE server |
-| Claude CLI background / foreground | `#121314` / `#E5E5E5` | Terminal colors, independent of Eclipse's Terminal; apply immediately |
+| Claude Terminal background / foreground | `#121314` / `#E5E5E5` | Terminal colors, independent of Eclipse's Terminal; apply immediately |
 
 ## Architecture
 

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -2,14 +2,14 @@
 <?eclipse version="3.4"?>
 <plugin>
 
-   <!-- Claude Code View -->
+   <!-- Claude IDE Server View -->
    <extension point="org.eclipse.ui.views">
       <category
             id="com.anthropic.claudecode.eclipse.category"
             name="Claude Code"/>
       <view
             id="com.anthropic.claudecode.eclipse.ui.ClaudeCodeView"
-            name="Claude Code"
+            name="Claude IDE Server"
             icon="icons/claude-16.png"
             class="com.anthropic.claudecode.eclipse.ui.ClaudeCodeView"
             category="com.anthropic.claudecode.eclipse.category"
@@ -40,8 +40,8 @@
             name="Claude Code"/>
       <command
             id="com.anthropic.claudecode.eclipse.commands.toggle"
-            name="Toggle Claude Code"
-            description="Toggle the Claude Code terminal panel"
+            name="Toggle Claude IDE Server"
+            description="Toggle the Claude IDE Server view"
             categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
       <command
             id="com.anthropic.claudecode.eclipse.commands.sendSelection"
@@ -122,7 +122,7 @@
                mnemonic="C">
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.toggle"
-                  label="Toggle Claude Code"
+                  label="Toggle Claude IDE Server"
                   mnemonic="T"
                   style="push"/>
             <command

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -25,7 +25,7 @@
             restorable="true"/>
       <view
             id="com.anthropic.claudecode.eclipse.ui.ClaudeCliView"
-            name="Claude CLI"
+            name="Claude Terminal"
             icon="icons/claude-16.png"
             class="com.anthropic.claudecode.eclipse.ui.ClaudeCliView"
             category="com.anthropic.claudecode.eclipse.category"
@@ -65,8 +65,8 @@
             categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
       <command
             id="com.anthropic.claudecode.eclipse.commands.activateCli"
-            name="Activate Claude CLI"
-            description="Open the Claude CLI view"
+            name="Activate Claude Terminal"
+            description="Open the Claude Terminal view"
             categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
    </extension>
 
@@ -127,7 +127,7 @@
                   style="push"/>
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
-                  label="Activate Claude CLI"
+                  label="Activate Claude Terminal"
                   mnemonic="L"
                   style="push"/>
             <command
@@ -175,9 +175,9 @@
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
                   icon="icons/claude-16.png"
-                  label="Activate Claude CLI"
+                  label="Activate Claude Terminal"
                   style="push"
-                  tooltip="Activate Claude CLI"/>
+                  tooltip="Activate Claude Terminal"/>
          </toolbar>
       </menuContribution>
    </extension>
@@ -194,11 +194,11 @@
    <extension point="org.eclipse.ui.themes">
       <fontDefinition
             id="com.anthropic.claudecode.eclipse.font.console"
-            label="Claude CLI Console Font"
+            label="Claude Terminal Console Font"
             categoryId="org.eclipse.ui.workbenchMisc"
             defaultsTo="org.eclipse.jface.textfont">
          <description>
-            The font used for the Claude CLI terminal console.
+            The font used for the Claude Terminal.
          </description>
       </fontDefinition>
    </extension>
@@ -213,7 +213,7 @@
       <startup class="com.anthropic.claudecode.eclipse.ClaudeStartup"/>
    </extension>
 
-   <!-- Register Claude CLI in Show In menu (Package Explorer works, Project Explorer is CNF limitation) -->
+   <!-- Register Claude Terminal in Show In menu (Package Explorer works, Project Explorer is CNF limitation) -->
    <extension point="org.eclipse.ui.perspectiveExtensions">
       <!-- Java -->
       <perspectiveExtension targetID="org.eclipse.jdt.ui.JavaPerspective">
@@ -341,7 +341,7 @@
       </perspectiveExtension>
    </extension>
 
-   <!-- Open Claude CLI Here - context menu for navigators -->
+   <!-- Open Claude Terminal Here - context menu for navigators -->
    <extension point="org.eclipse.ui.popupMenus">
       <objectContribution
             id="com.anthropic.claudecode.eclipse.openCliHere"
@@ -349,7 +349,7 @@
             adaptable="true">
          <action
                id="com.anthropic.claudecode.eclipse.actions.openCliHere"
-               label="Open Claude CLI Here"
+               label="Open Claude Terminal Here"
                icon="icons/claude-16.png"
                class="com.anthropic.claudecode.eclipse.ui.actions.OpenCliHereAction"/>
       </objectContribution>

--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -121,15 +121,16 @@
                label="Claude Code"
                mnemonic="C">
             <command
-                  commandId="com.anthropic.claudecode.eclipse.commands.toggle"
-                  label="Toggle Claude IDE Server"
-                  mnemonic="T"
-                  style="push"/>
-            <command
                   commandId="com.anthropic.claudecode.eclipse.commands.activateCli"
                   label="Activate Claude Terminal"
                   mnemonic="L"
                   style="push"/>
+            <command
+                  commandId="com.anthropic.claudecode.eclipse.commands.resume"
+                  label="Resume Session"
+                  mnemonic="R"
+                  style="push"/>
+            <separator name="com.anthropic.claudecode.eclipse.separator1" visible="true"/>
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.sendSelection"
                   label="Send Selection to Claude"
@@ -137,18 +138,8 @@
                   style="push"/>
             <command
                   commandId="com.anthropic.claudecode.eclipse.commands.addFile"
-                  label="Add File to Claude Context"
+                  label="Add File to Claude"
                   mnemonic="A"
-                  style="push"/>
-            <separator name="com.anthropic.claudecode.eclipse.separator1" visible="true"/>
-            <command
-                  commandId="com.anthropic.claudecode.eclipse.commands.resume"
-                  label="Resume Session"
-                  mnemonic="R"
-                  style="push"/>
-            <command
-                  commandId="com.anthropic.claudecode.eclipse.commands.restart"
-                  label="Restart Server"
                   style="push"/>
          </menu>
       </menuContribution>

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -21,19 +21,19 @@ public final class Constants {
     public static final String PREF_AUTO_LAUNCH_CLI = "autoLaunchCli";
     public static final String PREF_DEBUG_MODE = "debugMode";
 
-    /** Set once the user dismisses the Ctrl+Click hint bar in the Claude CLI view (per-workspace). */
+    /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */
     public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
 
     public static final String PREF_HTTP_PROXY = "httpProxy";
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";
 
-    /** Claude CLI terminal colors (independent of Eclipse's Terminal prefs).
+    /** Claude Terminal colors (independent of Eclipse's Terminal prefs).
      *  Stored as PreferenceConverter RGB strings ("r,g,b"). */
     public static final String PREF_CONSOLE_BG_COLOR = "consoleBgColor";
     public static final String PREF_CONSOLE_FG_COLOR = "consoleFgColor";
 
-    // ── Claude CLI status bar (statusLine) ──────────────────────────────────
+    // ── Claude Terminal status bar (statusLine) ─────────────────────────────
     /** Master switch: inject the statusLine and show the per-tab status bar. */
     public static final String PREF_STATUSLINE_ENABLED = "statuslineEnabled";
     /** Per-element visibility toggles (apply live in the bar render path). */

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -78,7 +78,7 @@ import com.anthropic.claudecode.eclipse.resolvers.EntitiesRegistry;
 import com.anthropic.claudecode.eclipse.status.StandaloneStatusForwarder;
 
 /**
- * Claude CLI view: a tabbed view ("Claude 1", "Claude 2", …) where each tab
+ * Claude Terminal view: a tabbed view ("Claude 1", "Claude 2", …) where each tab
  * embeds an Eclipse terminal control running the Claude CLI.
  *
  * <p>The terminal is the Eclipse terminal control ({@code org.eclipse.terminal})
@@ -304,13 +304,13 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
 
     private void configureActionBars() {
         IToolBarManager toolBar = getViewSite().getActionBars().getToolBarManager();
-        Action newSession = new Action("New Claude CLI Session") {
+        Action newSession = new Action("New Claude Terminal Session") {
             @Override
             public void run() {
                 openNewSession(null, null);
             }
         };
-        newSession.setToolTipText("New Claude CLI Session");
+        newSession.setToolTipText("New Claude Terminal Session");
         newSession.setImageDescriptor(Activator.getImageDescriptor(Constants.IMG_NEW_CLI_SESSION));
         toolBar.add(newSession);
         toolBar.add(new Separator());

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -304,13 +304,13 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
 
     private void configureActionBars() {
         IToolBarManager toolBar = getViewSite().getActionBars().getToolBarManager();
-        Action newSession = new Action("New Claude Terminal Session") {
+        Action newSession = new Action("New Session") {
             @Override
             public void run() {
                 openNewSession(null, null);
             }
         };
-        newSession.setToolTipText("New Claude Terminal Session");
+        newSession.setToolTipText("New Claude Session");
         newSession.setImageDescriptor(Activator.getImageDescriptor(Constants.IMG_NEW_CLI_SESSION));
         toolBar.add(newSession);
         toolBar.add(new Separator());

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCodeView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCodeView.java
@@ -85,7 +85,7 @@ public class ClaudeCodeView extends ViewPart {
 
         startPhpBridge();
         logBridgeInfo();
-        appendLog("Click 'Launch Claude Terminal' to open the Claude CLI.\n\n");
+        appendLog("Click 'Launch Claude Terminal' to open the Claude Terminal.\n\n");
 
         updateStatus();
         startStatusPoller();
@@ -259,8 +259,8 @@ public class ClaudeCodeView extends ViewPart {
             ClaudeCliView cliView = (ClaudeCliView) page.showView(ClaudeCliView.VIEW_ID);
             cliView.launchProcess(extraArgs);
         } catch (PartInitException e) {
-            appendLog("[ERROR] Could not open Claude CLI view: " + e.getMessage() + "\n");
-            Activator.logError("Failed to open Claude CLI view", e);
+            appendLog("[ERROR] Could not open Claude Terminal view: " + e.getMessage() + "\n");
+            Activator.logError("Failed to open Claude Terminal view", e);
         } finally {
             Display.getCurrent().timerExec(500, () -> launching = false);
         }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCodeView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCodeView.java
@@ -180,13 +180,13 @@ public class ClaudeCodeView extends ViewPart {
         launchButton.setText("Launch Terminal");
         launchButton.addListener(SWT.Selection, e -> startClaude());
 
-        Button restartBtn = new Button(buttonRow, SWT.PUSH);
-        restartBtn.setText("Restart Server");
-        restartBtn.addListener(SWT.Selection, e -> restartServer());
-
         Button resumeBtn = new Button(buttonRow, SWT.PUSH);
         resumeBtn.setText("Resume Session");
         resumeBtn.addListener(SWT.Selection, e -> restartClaude("--resume"));
+
+        Button restartBtn = new Button(buttonRow, SWT.PUSH);
+        restartBtn.setText("Restart Server");
+        restartBtn.addListener(SWT.Selection, e -> restartServer());
     }
 
     private void createLogArea(Composite parent, Display display) {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -29,7 +29,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_HTTPS_PROXY, "");
         store.setDefault(Constants.PREF_NO_PROXY, "");
 
-        // Claude CLI status bar (statusLine) — on by default, except the thinking segment.
+        // Claude Terminal status bar (statusLine) — on by default, except the thinking segment.
         store.setDefault(Constants.PREF_STATUSLINE_ENABLED, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_MODEL, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_EFFORT, true);
@@ -40,7 +40,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY, true);
         store.setDefault(Constants.PREF_STATUSLINE_REFRESH_SECONDS, 60);
 
-        // Claude CLI terminal colors — default to the dark look (#121314 / #E5E5E5).
+        // Claude Terminal colors — default to the dark look (#121314 / #E5E5E5).
         PreferenceConverter.setDefault(store, Constants.PREF_CONSOLE_BG_COLOR, new RGB(0x12, 0x13, 0x14));
         PreferenceConverter.setDefault(store, Constants.PREF_CONSOLE_FG_COLOR, new RGB(0xE5, 0xE5, 0xE5));
     }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -71,7 +71,7 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
 
         addField(new BooleanFieldEditor(
                 Constants.PREF_AUTO_LAUNCH_CLI,
-                "Auto-launch Claude CLI on workspace open",
+                "Auto-launch Claude Terminal on workspace open",
                 getFieldEditorParent()));
 
         addField(new BooleanFieldEditor(
@@ -79,22 +79,22 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 "Debug mode",
                 getFieldEditorParent()));
 
-        // Claude CLI terminal colors — independent of Eclipse's Terminal colors.
+        // Claude Terminal colors — independent of Eclipse's Terminal colors.
         addField(new ColorFieldEditor(
                 Constants.PREF_CONSOLE_BG_COLOR,
-                "Claude CLI background:",
+                "Claude Terminal background:",
                 getFieldEditorParent()));
 
         addField(new ColorFieldEditor(
                 Constants.PREF_CONSOLE_FG_COLOR,
-                "Claude CLI foreground:",
+                "Claude Terminal foreground:",
                 getFieldEditorParent()));
 
         Label statusSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);
         statusSeparator.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 
         Label statusLabel = new Label(getFieldEditorParent(), SWT.NONE);
-        statusLabel.setText("Claude CLI status bar configuration:");
+        statusLabel.setText("Claude Terminal status bar configuration:");
         statusLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 
         statuslineEnabled = new BooleanFieldEditor(

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
@@ -25,7 +25,7 @@ import com.anthropic.claudecode.eclipse.Activator;
 import com.anthropic.claudecode.eclipse.Constants;
 
 /**
- * Per-tab status strip for the Claude CLI view: a one-line, at-a-glance indicator of the
+ * Per-tab status strip for the Claude Terminal view: a one-line, at-a-glance indicator of the
  * current model, effort level, thinking indicator, context-window usage, session cost, and the
  * 5-hour/weekly subscription usage limits (with reset countdowns). It is fed by {@link #setStatus}
  * from  {@code StatusBridge}.

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/OpenEntityHandler.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/OpenEntityHandler.java
@@ -20,7 +20,7 @@ import com.anthropic.claudecode.eclipse.resolvers.EntitiesRegistry;
 import com.anthropic.claudecode.eclipse.resolvers.EntitiesRegistry.NamedResolvedEntity;
 
 /**
- * Opens an entity from the Claude CLI terminal, either on Ctrl/Cmd + left-click (the hovered
+ * Opens an entity from the Claude Terminal, either on Ctrl/Cmd + left-click (the hovered
  * token) or on demand from the context menu (the current selection).
  *
  * <p>The mouse gesture is modeled on Eclipse's {@code OpenFileMouseHandler} (only MOD1 +
@@ -86,7 +86,7 @@ public class OpenEntityHandler implements ITerminalMouseListener {
 		}
 		statusLine.setErrorMessage(null);
 		statusLine.setMessage("Opening entity from \""+text+"\"...");
-		Job job = new Job("Resolving entity from Claude CLI") {
+		Job job = new Job("Resolving entity from Claude Terminal") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				List<NamedResolvedEntity> entities = registry.resolve(text, allowStripEdges);
@@ -127,7 +127,7 @@ public class OpenEntityHandler implements ITerminalMouseListener {
 	private void showChooser(List<NamedResolvedEntity> entities) {
 		Control canvas = terminal.getControl();
 		if (canvas == null || canvas.isDisposed()) {
-			statusLine.setErrorMessage("Could not show the entity chooser: Claude CLI is unavailable.");
+			statusLine.setErrorMessage("Could not show the entity chooser: Claude Terminal is unavailable.");
 			return;
 		}
 		Menu menu = new Menu(canvas);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/actions/OpenCliHereAction.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/actions/OpenCliHereAction.java
@@ -70,7 +70,7 @@ public class OpenCliHereAction implements IObjectActionDelegate {
             ClaudeCliView view = (ClaudeCliView) page.showView(ClaudeCliView.VIEW_ID);
             view.launchProcessInDirectory(cwd, label);
         } catch (Exception e) {
-            Activator.logError("Failed to open Claude CLI", e);
+            Activator.logError("Failed to open Claude Terminal", e);
         }
     }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/ActivateClaudeCliHandler.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/ActivateClaudeCliHandler.java
@@ -23,7 +23,7 @@ public class ActivateClaudeCliHandler extends AbstractHandler {
             ClaudeCliView view = (ClaudeCliView) page.showView(ClaudeCliView.VIEW_ID);
             if (view != null) view.ensureAtLeastOneTab();
         } catch (Exception e) {
-            Activator.logError("Failed to activate Claude CLI view", e);
+            Activator.logError("Failed to activate Claude Terminal view", e);
         }
         return null;
     }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/AddFileHandler.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/AddFileHandler.java
@@ -70,7 +70,7 @@ public class AddFileHandler extends AbstractHandler {
             if (view != null) view.ensureAtLeastOneTab();
             return view;
         } catch (Exception e) {
-            Activator.logError("Failed to open Claude CLI view", e);
+            Activator.logError("Failed to open Claude Terminal view", e);
             return null;
         }
     }


### PR DESCRIPTION
This is the implementation of #66.
1. The following renamings are done:
```
"Claude CLI" => "Claude Terminal"
"Claude Code" => "Claude IDE Server"
```
2. Current "Claude Chat" view **is not** renamed, as it will be replaced with the view on `dev` branch. @eilonwy06, please name the new replacement view "Claude Code" or maybe "Claude Chat".
3. Main menu was reorganized, so similar actions a located nearby:

Before:
<img width="334" height="166" alt="claude-eclipse-menu" src="https://github.com/user-attachments/assets/22f3150b-d19c-47c7-8c11-462ebff52396" />

After:
<img width="286" height="148" alt="claude_main_menu" src="https://github.com/user-attachments/assets/b2d960e3-6799-4fe1-961f-37894e01194d" />

4. "Claude IDE Server" was removed from the main menu, as it seems not important for a user, but it is still accessible via standard Eclipse open view action.

@eilonwy06, these changes are implemented as separate commits, so we could easily apply or revert some of them. Feel free to fix the PR if you don't agree with something (or leave the comments -- I'll fix).

Also for v3 release I think we need to review and actualize the README.md, as some UX has changed (e.g. a user don't need to open Claude IDE Server view to work with Claude etc). Also maybe we should divide it into a user-specific and a developer-specific file.

One more thing for v3 release is probably to update the screenshots on Eclipse marketplace.