### PR TITLE
Move Claude Terminal colors and font to general Colors and Fonts

### DIFF
--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -207,12 +207,40 @@
             class="com.anthropic.claudecode.eclipse.ui.ClaudePreferencePage"/>
    </extension>
 
-   <!-- Font Definition -->
+   <!-- Colors and Fonts (General > Appearance > Colors and Fonts) -->
    <extension point="org.eclipse.ui.themes">
+      <themeElementCategory
+            id="com.anthropic.claudecode.eclipse.themeCategory"
+            label="Claude Code">
+         <description>
+            Colors and fonts for the Claude Code integration.
+         </description>
+      </themeElementCategory>
+
+      <colorDefinition
+            id="com.anthropic.claudecode.eclipse.color.terminalBackground"
+            label="Claude Terminal Background"
+            categoryId="com.anthropic.claudecode.eclipse.themeCategory"
+            value="18,19,20">
+         <description>
+            The background color of the Claude Terminal.
+         </description>
+      </colorDefinition>
+
+      <colorDefinition
+            id="com.anthropic.claudecode.eclipse.color.terminalForeground"
+            label="Claude Terminal Foreground"
+            categoryId="com.anthropic.claudecode.eclipse.themeCategory"
+            value="229,229,229">
+         <description>
+            The foreground (text) color of the Claude Terminal.
+         </description>
+      </colorDefinition>
+
       <fontDefinition
             id="com.anthropic.claudecode.eclipse.font.console"
-            label="Claude Terminal Console Font"
-            categoryId="org.eclipse.ui.workbenchMisc"
+            label="Claude Terminal Font"
+            categoryId="com.anthropic.claudecode.eclipse.themeCategory"
             defaultsTo="org.eclipse.jface.textfont">
          <description>
             The font used for the Claude Terminal.

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -28,11 +28,6 @@ public final class Constants {
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";
 
-    /** Claude Terminal colors (independent of Eclipse's Terminal prefs).
-     *  Stored as PreferenceConverter RGB strings ("r,g,b"). */
-    public static final String PREF_CONSOLE_BG_COLOR = "consoleBgColor";
-    public static final String PREF_CONSOLE_FG_COLOR = "consoleFgColor";
-
     // ── Claude Terminal status bar (statusLine) ─────────────────────────────
     /** Master switch: inject the statusLine and show the per-tab status bar. */
     public static final String PREF_STATUSLINE_ENABLED = "statuslineEnabled";

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.jface.preference.PreferenceStore;
+import org.eclipse.jface.resource.ColorRegistry;
 import org.eclipse.jface.resource.FontRegistry;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.util.IPropertyChangeListener;
@@ -99,6 +100,13 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     /** Font definition ID from plugin.xml (Colors and Fonts preference). */
     private static final String FONT_ID = "com.anthropic.claudecode.eclipse.font.console";
 
+    /** Color definition IDs from plugin.xml (Colors and Fonts > Claude Code). */
+    private static final String COLOR_BG_ID = "com.anthropic.claudecode.eclipse.color.terminalBackground";
+    private static final String COLOR_FG_ID = "com.anthropic.claudecode.eclipse.color.terminalForeground";
+    // Fallbacks matching the plugin.xml defaults, used only if the theme registry is unavailable.
+    private static final RGB DEFAULT_BG = new RGB(0x12, 0x13, 0x14);
+    private static final RGB DEFAULT_FG = new RGB(0xE5, 0xE5, 0xE5);
+
     /**
      * Dedicated JFaceResources key the terminal resolves for BOTH drawing and
      * cell-grid measurement. We mirror the user's console font ({@link #FONT_ID},
@@ -118,7 +126,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     // Perceived-luminance cutoff (of 255) below which the terminal background counts as dark.
     private static final double DARK_BG_LUMINANCE_THRESHOLD = 128;
 
-    // Active terminal colors, read from the PREF_CONSOLE_BG/FG_COLOR preferences
+    // Active terminal colors, read from the COLOR_BG_ID/COLOR_FG_ID theme colors
     // (user-configurable, independent of Eclipse's shared Terminal colors).
     private int bgR, bgG, bgB;
     private int fgR, fgG, fgB;
@@ -130,7 +138,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     private boolean launching = false;
     private Color bgColor;
     private IPropertyChangeListener fontChangeListener;
-    private IPropertyChangeListener themeChangeListener;
+    private IPropertyChangeListener colorChangeListener;
     private Action scrollLockAction;
 
     /** Shared entity resolver registry for Ctrl-click navigation, one per view. */
@@ -192,17 +200,16 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         };
         JFaceResources.getFontRegistry().addListener(fontChangeListener);
 
-        themeChangeListener = event -> {
+        colorChangeListener = event -> {
             String p = event.getProperty();
-            if (Constants.PREF_CONSOLE_BG_COLOR.equals(p)
-                    || Constants.PREF_CONSOLE_FG_COLOR.equals(p)) {
+            if (COLOR_BG_ID.equals(p) || COLOR_FG_ID.equals(p)) {
                 display.asyncExec(() -> {
                     if (viewDisposed || tabFolder == null || tabFolder.isDisposed()) return;
                     applyTheme();
                 });
             }
         };
-        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(themeChangeListener);
+        JFaceResources.getColorRegistry().addListener(colorChangeListener);
     }
 
     private void applyTheme() {
@@ -331,16 +338,16 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     }
 
     private void setThemeColors(Display display) {
-        // Background/foreground come from the user-configurable preferences.
-        IPreferenceStore store = Activator.getDefault().getPreferenceStore();
-        RGB bg = PreferenceConverter.getColor(store, Constants.PREF_CONSOLE_BG_COLOR);
-        RGB fg = PreferenceConverter.getColor(store, Constants.PREF_CONSOLE_FG_COLOR);
+        // Background/foreground come from the user-configurable Colors and Fonts entries
+        // (General > Appearance > Colors and Fonts > Claude Code).
+        RGB bg = themeColor(COLOR_BG_ID, DEFAULT_BG);
+        RGB fg = themeColor(COLOR_FG_ID, DEFAULT_FG);
         bgR = bg.red; bgG = bg.green; bgB = bg.blue;
         fgR = fg.red; fgG = fg.green; fgB = fg.blue;
         bgColor = new Color(display, bgR, bgG, bgB);
 
         // COLORFGBG tells Claude's "/theme auto" whether its background is dark or light. We derive it
-        // from the actual configured terminal background (PREF_CONSOLE_BG_COLOR), not Eclipse's
+        // from the actual configured terminal background (the COLOR_BG_ID color), not Eclipse's
         // General > Appearance theme: that color is what is genuinely painted behind the terminal (and
         // can differ from the SWT widget/theme color), so its luminance is the ground truth for the hint.
         // This keeps it correct for any custom color and avoids the discouraged x-friends IThemeEngine
@@ -545,9 +552,9 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             JFaceResources.getFontRegistry().removeListener(fontChangeListener);
             fontChangeListener = null;
         }
-        if (themeChangeListener != null) {
-            Activator.getDefault().getPreferenceStore().removePropertyChangeListener(themeChangeListener);
-            themeChangeListener = null;
+        if (colorChangeListener != null) {
+            JFaceResources.getColorRegistry().removeListener(colorChangeListener);
+            colorChangeListener = null;
         }
         if (tabFolder != null && !tabFolder.isDisposed()) {
             for (CTabItem item : tabFolder.getItems()) {
@@ -601,6 +608,20 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             if (f.isFile() && f.canExecute()) return f.getAbsolutePath();
         }
         return cmd;
+    }
+
+    /** A Claude Terminal color ({@link #COLOR_BG_ID}/{@link #COLOR_FG_ID}) from the
+     *  workbench theme registry, falling back to {@code fallback} if unavailable. */
+    private RGB themeColor(String id, RGB fallback) {
+        try {
+            ColorRegistry themeReg = PlatformUI.getWorkbench().getThemeManager()
+                    .getCurrentTheme().getColorRegistry();
+            RGB rgb = themeReg.getRGB(id);
+            if (rgb != null) return rgb;
+        } catch (Exception ignore) {
+            // Workbench/theme unavailable — fall through.
+        }
+        return fallback;
     }
 
     /** The user's console font ({@link #FONT_ID}) from the theme registry, with

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -2,8 +2,6 @@ package com.anthropic.claudecode.eclipse.ui;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.jface.preference.PreferenceConverter;
-import org.eclipse.swt.graphics.RGB;
 
 import com.anthropic.claudecode.eclipse.Activator;
 import com.anthropic.claudecode.eclipse.Constants;
@@ -39,9 +37,5 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_SESSION_5H, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY, true);
         store.setDefault(Constants.PREF_STATUSLINE_REFRESH_SECONDS, 60);
-
-        // Claude Terminal colors — default to the dark look (#121314 / #E5E5E5).
-        PreferenceConverter.setDefault(store, Constants.PREF_CONSOLE_BG_COLOR, new RGB(0x12, 0x13, 0x14));
-        PreferenceConverter.setDefault(store, Constants.PREF_CONSOLE_FG_COLOR, new RGB(0xE5, 0xE5, 0xE5));
     }
 }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
-import org.eclipse.jface.preference.ColorFieldEditor;
 import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -77,17 +76,6 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         addField(new BooleanFieldEditor(
                 Constants.PREF_DEBUG_MODE,
                 "Debug mode",
-                getFieldEditorParent()));
-
-        // Claude Terminal colors — independent of Eclipse's Terminal colors.
-        addField(new ColorFieldEditor(
-                Constants.PREF_CONSOLE_BG_COLOR,
-                "Claude Terminal background:",
-                getFieldEditorParent()));
-
-        addField(new ColorFieldEditor(
-                Constants.PREF_CONSOLE_FG_COLOR,
-                "Claude Terminal foreground:",
                 getFieldEditorParent()));
 
         Label statusSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);


### PR DESCRIPTION
Add a 'Claude Code' category under General > Appearance > Colors and Fonts holding the terminal background, foreground and font (renamed to 'Claude Terminal Font'). The two colors are now theme colorDefinitions read from the workbench color registry instead of ColorFieldEditors on the plugin's own preference page.

Note: migration of previously customized colors (old consoleBgColor / consoleFgColor preference keys) is not implemented; those values reset once to the new theme defaults and must be re-picked in Colors and Fonts.

Implements #72 