### PR TITLE
fix: Emacs-style key bindings (Ctrl+Y, Ctrl+X H, etc.) misbehave on GTK

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/contextmenu.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/contextmenu.js
@@ -108,7 +108,12 @@ function ccPaste(el) {
      both — its words into the composer, its images as chips — while a copied image on its
      own attaches only the image, so the platform's text alternative for it (a URL, a file
      name) doesn't end up in the composer as well. Images the fragment names by URL are
-     downloaded by the host and arrive later through __ccFetchedImages. */
+     downloaded by the host and arrive later through __ccFetchedImages.
+
+     This runs unconditionally, even on the Ctrl+V native-paste path below: a copied
+     file-manager path or a remote <img> URL in an HTML fragment has no bitmap on the DOM
+     event for images.js's own paste listener to find, so this host round trip is the only
+     way those become chips, on every binding including Ctrl+V. */
   if (window._clipImages) {
     let r = null;
     try { r = JSON.parse(_clipImages(ccTabId()) || 'null'); } catch (e) { r = null; }
@@ -117,6 +122,19 @@ function ccPaste(el) {
       if (r.text === false) return;
     }
   }
+  /* On GTK, Ctrl+V is recognized by WebKit itself as a paste shortcut, independent of
+     Eclipse's dispatcher — it fires a native DOM paste event on the composer, which
+     pastes the clipboard's TEXT (images.js's listener only handles a bitmap item; see
+     above for the rest), before the host's org.eclipse.ui.edit.paste handler even runs
+     (browser.execute() queues the handler's injected script behind the page's own
+     pending key processing, the same ordering issue #97's stray-character fix works
+     around). So: if a real paste event landed on the composer in roughly the same
+     instant as this call, its native paste already inserted the text, and inserting it
+     again here is what put it in twice. A window this short can't collide with an
+     unrelated later paste, and Emacs's Ctrl+Y produces no native paste event at all —
+     the only key WebKit treats as its own paste shortcut is Ctrl+V — so Ctrl+Y always
+     reaches the insert below. */
+  if (window.__ccLastPaste && Date.now() - window.__ccLastPaste < 300) return;
   if (window._clipGet) { ccInsertText(String(_clipGet() || ''), el); return; }
   if (navigator.clipboard && navigator.clipboard.readText) {
     navigator.clipboard.readText()
@@ -133,23 +151,9 @@ function ccPaste(el) {
    string to escape in either direction. */
 window.__ccCopy = () => ccCopy();
 window.__ccCut = () => ccCut();
-window.__ccPaste = () => { ccFlagHostPaste(); ccPaste(); };
+window.__ccPaste = () => ccPaste();
 window.__ccSelectAll = () => ccSelectAll();
 window.__ccDelete = () => ccDeleteForward();
-
-/* Marks the paste we are about to do as ours. On Windows and macOS the webview is told
-   Eclipse consumed the keystroke and never acts on it, but GTK has no way to say that,
-   so WebKit goes on to run its own paste and the text lands twice (issue #97). The
-   composer's paste listener drops the one that follows this flag. It is a one-shot with
-   a short life on purpose: a middle-click paste arrives with nothing flagged and is left
-   alone, and if the flag were ever set too late we are back to the doubled paste rather
-   than to no paste at all. */
-let ccHostPasteTimer = 0;
-function ccFlagHostPaste() {
-  window.__ccHostPaste = true;
-  clearTimeout(ccHostPasteTimer);
-  ccHostPasteTimer = setTimeout(() => { window.__ccHostPaste = false; }, 250);
-}
 
 /* Reports the keys this page sees to the host's log, which is the other half of the
    picture from the [EDIT] lines: on Linux the webview hands Eclipse the same press more

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/images.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/images.js
@@ -181,12 +181,13 @@ function renderPendingImages() {
 
 /* Capture image paste on the composer. A screenshot paste arrives as a file item
    with an image/* MIME type; when present we consume the event so the textarea
-   doesn't also paste a filename/text alternative. Plain-text paste is untouched. */
+   doesn't also paste a filename/text alternative. Plain-text paste is untouched.
+
+   Only Ctrl+V produces this DOM event at all — see the comment on window.__ccLastPaste
+   in contextmenu.js for why ccPaste() (the host's org.eclipse.ui.edit.paste handler,
+   and the right-click menu's Paste item) needs to know this one just happened. */
 input.addEventListener('paste', (e) => {
-  /* A paste we just performed ourselves — see ccFlagHostPaste. Letting WebKit run its
-     own paste on top of ours is what puts the text in twice on GTK, so this one is
-     dropped. Only ours: a middle-click paste is unflagged and pastes normally. */
-  if (window.__ccHostPaste) { window.__ccHostPaste = false; e.preventDefault(); return; }
+  window.__ccLastPaste = Date.now();
   const data = e.clipboardData;
   if (!data) return;
   let took = false;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -149,6 +149,77 @@ input.addEventListener('beforeinput', (e) => {
   if (/^[\u0000-\u001F\u007F-\u009F]+$/.test(e.data)) e.preventDefault();
 });
 
+/* A key bound to one of Eclipse's org.eclipse.ui.edit.* commands (issue #97): on GTK,
+   the dispatcher consuming the keystroke (doit=false) doesn't stop WebKit from ALSO
+   inserting it as text once the key carries a plain, unmodified character -- an Emacs
+   Ctrl+X H both selects all AND types "h" into the composer.
+
+   The natural fix would be to arm a guard before running the command and have it
+   preventDefault() the stray beforeinput. That does NOT work: browser.execute() on
+   WebKitGTK queues the injected script behind the page's own pending key processing,
+   so the arm call lands in the page strictly AFTER the stray keydown/beforeinput for
+   that same keystroke has already run and inserted the character (confirmed against a
+   live GTK build -- the arm log line comes after the insert's beforeinput line, not
+   before). There is no preventing an insert that already happened by the time we're
+   able to say anything about it.
+
+   So this undoes it instead. Every single-character insertText beforeinput on the
+   composer is recorded (character + position); when the command's own arm call
+   arrives afterward carrying the SAME character, the just-inserted character at that
+   recorded position is deleted. Both the record and the arm are one-shot and scoped
+   to the exact character, so ordinary typing (no arm ever follows it) and an edit
+   command that inserts nothing (e.g. Delete, which never arms -- see
+   activateEditHandler) are both untouched. execCommand('delete') is used rather than
+   setRangeText so the removal stays on the textarea's native undo stack, same as
+   ccDeleteSelection.
+
+   Arming (and therefore undoing) is refused unless the composer already has focus.
+   selectAll works on the transcript too when the composer isn't focused (see
+   ccSelectAll/ccField), and a stray GTK insert can only ever land in whatever field
+   the keystroke's own focus was in -- so an edit op that ran against the transcript
+   never gets a beforeinput on #input to record, and there is nothing here to undo. */
+let ccLastInsert = null;   // { code, at, pos, replaced } -- pos is the caret position right
+                           // after the insert; replaced is whatever selection the insert
+                           // overwrote (usually "", but not when the stray keystroke lands
+                           // while a chord's own selectAll has something selected already --
+                           // see below).
+input.addEventListener('beforeinput', (e) => {
+  if (e.inputType === 'insertText' && e.data && e.data.length === 1) {
+    ccLastInsert = {
+      code: e.data.codePointAt(0), at: Date.now(),
+      pos: input.selectionStart + 1,
+      replaced: input.value.slice(input.selectionStart, input.selectionEnd),
+    };
+  }
+});
+window.__ccArmKeyGuard = (code) => {
+  if (document.activeElement !== input) return;
+  const ins = ccLastInsert;
+  ccLastInsert = null;   // one-shot regardless of match
+  if (!ins || ins.code !== code || Date.now() - ins.at > 500) return;
+  const pos = Math.min(ins.pos, input.value.length);
+  input.focus();
+  input.setSelectionRange(pos - 1, pos);
+  // Undoing this insert means putting back whatever it overwrote -- usually nothing, but
+  // a chord repeated right after its own selectAll (Ctrl+X H, Ctrl+X H) has that command's
+  // selection still live when the second H's stray insert lands, and REPLACES it. Deleting
+  // the "h" alone would not bring the replaced text back; insertText with the saved
+  // replacement does, and re-selecting it after matches what the user actually had before
+  // op.run() (queued right after this call) reads the selection for copy/cut.
+  let ok;
+  if (ins.replaced) {
+    ok = document.execCommand('insertText', false, ins.replaced);
+    if (ok) input.setSelectionRange(pos - 1, pos - 1 + ins.replaced.length);
+  } else {
+    ok = document.execCommand('delete');
+  }
+  if (!ok) {
+    input.setRangeText(ins.replaced, pos - 1, pos, 'start');
+    input.setSelectionRange(pos - 1, pos - 1 + ins.replaced.length);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+};
+
 input.addEventListener('keydown', (e) => {
   // Set before the slash menu gets a look in: it claims Up/Down but never the
   // horizontal arrows, so a guard set here is always the one this keypress needs.

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -109,6 +109,12 @@ public class ClaudeGuiView extends ViewPart {
     private final java.util.List<org.eclipse.ui.handlers.IHandlerActivation> editHandlers =
             new java.util.ArrayList<>();
 
+    // The (time, keyCode, stateMask) of the last SWT.KeyDown an edit handler acted on — see
+    // activateEditHandler. On GTK the same physical keystroke can reach Eclipse's key-binding
+    // dispatcher more than once (issue #97: Alt-combos deliver the character KeyDown three
+    // times, same timestamp each time); this collapses those repeats into one execution.
+    private String lastHandledKeyEvent = null;
+
     // Status bar (the shared SWT ClaudeStatusBar widget, reused from the CLI view).
     private ClaudeStatusBar statusBar;
     // Live-applies PREF_STATUSLINE_* changes (enable/toggles/refresh) without a restart.
@@ -886,7 +892,18 @@ public class ClaudeGuiView extends ViewPart {
                 ClaudeCodeView.debug("[EDIT] execute " + commandId + " (handled=" + isHandled()
                         + ", pageLoaded=" + pageLoaded + ", editOpsReady=" + editOpsReady
                         + ", time=" + when + ")");
-                if (isHandled()) op.run();
+                if (!isHandled()) return null;
+                // A right-click menu invocation carries no SWT Event trigger at all, so it
+                // always runs. A key-binding invocation is deduped against the last one this
+                // view acted on: same keyCode/stateMask/time is the SAME physical keystroke
+                // delivered again, not a fresh press (see lastHandledKeyEvent, issue #97 —
+                // GTK can hand Eclipse's dispatcher one Alt-combo keystroke three times).
+                if (trigger instanceof org.eclipse.swt.widgets.Event swtEvent) {
+                    String key = swtEvent.keyCode + "/" + swtEvent.stateMask + "/" + swtEvent.time;
+                    if (key.equals(lastHandledKeyEvent)) return null;
+                    lastHandledKeyEvent = key;
+                }
+                op.run();
                 return null;
             }
         }));

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -887,21 +887,45 @@ public class ClaudeGuiView extends ViewPart {
                 // matched. Two runs of one command carrying the SAME timestamp are one
                 // press reported twice; auto-repeat carries a different one each time.
                 Object trigger = event.getTrigger();
-                String when = (trigger instanceof org.eclipse.swt.widgets.Event swtEvent)
-                        ? Integer.toString(swtEvent.time) : "n/a";
-                ClaudeCodeView.debug("[EDIT] execute " + commandId + " (handled=" + isHandled()
-                        + ", pageLoaded=" + pageLoaded + ", editOpsReady=" + editOpsReady
-                        + ", time=" + when + ")");
-                if (!isHandled()) return null;
+                org.eclipse.swt.widgets.Event swtEvent =
+                        trigger instanceof org.eclipse.swt.widgets.Event e ? e : null;
+                String when = swtEvent != null ? Integer.toString(swtEvent.time) : "n/a";
                 // A right-click menu invocation carries no SWT Event trigger at all, so it
                 // always runs. A key-binding invocation is deduped against the last one this
                 // view acted on: same keyCode/stateMask/time is the SAME physical keystroke
                 // delivered again, not a fresh press (see lastHandledKeyEvent, issue #97 —
                 // GTK can hand Eclipse's dispatcher one Alt-combo keystroke three times).
-                if (trigger instanceof org.eclipse.swt.widgets.Event swtEvent) {
-                    String key = swtEvent.keyCode + "/" + swtEvent.stateMask + "/" + swtEvent.time;
-                    if (key.equals(lastHandledKeyEvent)) return null;
+                // Checked before logging so the log itself says which of several same-
+                // timestamp dispatches actually ran, instead of showing "execute" three
+                // times over with nothing to tell them apart.
+                String key = swtEvent != null
+                        ? swtEvent.keyCode + "/" + swtEvent.stateMask + "/" + swtEvent.time : null;
+                boolean deduped = isHandled() && key != null && key.equals(lastHandledKeyEvent);
+                ClaudeCodeView.debug("[EDIT] execute " + commandId + " (handled=" + isHandled()
+                        + ", pageLoaded=" + pageLoaded + ", editOpsReady=" + editOpsReady
+                        + ", time=" + when + (deduped ? ", deduped" : "") + ")");
+                if (!isHandled() || deduped) return null;
+                if (swtEvent != null) {
                     lastHandledKeyEvent = key;
+                    // On GTK only, consuming this keystroke (doit=false, set by the
+                    // dispatcher once isHandled() claimed it) doesn't stop WebKit from also
+                    // inserting it as text -- confirmed for the plain, unmodified key that
+                    // completes an Emacs chord (Ctrl+X H selects all AND types "h", issue
+                    // #97). Windows/macOS honor the consume (see registerEditHandlers'
+                    // per-platform notes above), so arming there could only ever eat a
+                    // later, unrelated keystroke that happens to match -- gate on GTK.
+                    // Guard only a trigger that could actually produce that stray insert:
+                    // no Ctrl/Alt/Command, and a printable character (not e.g. plain DEL,
+                    // which is 0x7F and inserts nothing -- arming for it would leave the
+                    // guard armed for the NEXT keystroke instead, silently eating the
+                    // following typed letter). The armed value is the character itself, so
+                    // the page only drops an insert that actually matches this keystroke.
+                    char ch = swtEvent.character;
+                    if ("gtk".equals(SWT.getPlatform())
+                            && (swtEvent.stateMask & (SWT.CTRL | SWT.ALT | SWT.COMMAND)) == 0
+                            && ch >= 0x20 && ch != 0x7F) {
+                        executeJS("window.__ccArmKeyGuard && __ccArmKeyGuard(" + (int) ch + ")");
+                    }
                 }
                 op.run();
                 return null;


### PR DESCRIPTION
## Summary

Fixes issue #97 on GTK (Linux): custom-scheme key bindings on the prompt input — Emacs's Ctrl+Y (paste), Ctrl+W (cut), Ctrl+X H (select all), and plain Ctrl+V (paste) — misbehaved in three independent ways. Each is a separate GTK/WebKitGTK quirk with its own fix.

**1. One physical keystroke reaches Eclipse's key-binding dispatcher more than once.** An Alt- or Ctrl-combo keystroke inside the `Browser` can deliver the same `SWT.KeyDown` (identical timestamp) two or three times, so a command bound to one of the five `org.eclipse.ui.edit.*` handlers ran once per delivery instead of once per press — e.g. Ctrl+Y pasting 2-3x. Fixed by deduping consecutive key-triggered executions on `(keyCode, stateMask, time)`; a right-click menu invocation, which carries no SWT `Event` trigger, is unaffected.

**2. Consuming a keystroke doesn't stop WebKitGTK from also inserting its character.** Even once the dispatcher accepts a handler for the command (`doit=false`), GTK still lets the character reach the page — so `Ctrl+X H` both selects all *and* types "h". `preventDefault()` can't fix this: `browser.execute()` on WebKitGTK queues the injected script behind the page's own pending key processing, so a guard armed *before* running the command reaches the page strictly *after* that keystroke's `beforeinput` already fired and inserted the character. Fixed by undoing the stray insert after the fact instead: the composer records every single-character insert (character, caret position, replaced selection), and reverts it when the triggering command's own arm call arrives afterward with a matching character — deleting it if it replaced nothing, or restoring (and re-selecting) whatever it overwrote if it landed on a live selection, which happens when the same chord is pressed twice in a row.

**3. Ctrl+V's own native paste races the same way.** WebKit recognizes Ctrl+V as its own paste shortcut, independent of Eclipse's dispatcher, and fires a native DOM paste event that inserts the clipboard's text — before the queued host handler runs its own paste on top, so the text landed twice. d9b4de6's `ccFlagHostPaste` flag can't fix this for the same reason as #2: it's set too late to catch WebKit's native paste. Fixed the same way as #2, flipped: the composer now records when a real paste event fires, and the paste handler skips its own text insert if one landed within the last 300ms. Image-clipboard handling (a copied file-manager path or a remote `<img>` URL with no bitmap on the DOM event) still runs unconditionally, since that never reaches the page any other way.

All three fixes are scheme-agnostic: they key off the `org.eclipse.ui.edit.*` command and the triggering keystroke's own properties, not any Emacs-specific binding, so any custom scheme shaped the same way is covered. Fixes #2 and #3 are explicitly gated to GTK only (`SWT.getPlatform()`) and are no-ops on Windows/macOS, where `doit=false` is honored and no native Ctrl+V paste event races the handler. Fix #1 runs on all platforms but can only ever suppress a genuine duplicate delivery — it cannot change behavior on a platform that delivers each keystroke once.

## Testing

Verified interactively by the original reporter on the exact environment from the issue thread — Debian 13, GTK3, WebKitGTK 4.1, Emacs key scheme — with Debug mode on:

- `abc`, `Ctrl+X H`, `Shift+Enter`, `Ctrl+Y`, `Shift+Enter`, `Ctrl+V` → one `[EDIT] execute` per keystroke, no stray characters, no doubled paste
- `Ctrl+X H` pressed twice in a row → selection preserved correctly, no data loss
- Type text, `Delete`, then type a letter → letter appears normally
- Copy text, `Ctrl+X H`, paste → paste lands intact
- Plain `Ctrl+C` then `Ctrl+V` → pastes once
- Middle-click paste → still works
- Screenshot paste via `Ctrl+V` → exactly one image chip, not two
- Image file copied from the file manager, pasted via `Ctrl+V` and via `Ctrl+Y` → chip appears both ways
