### PR TITLE
fix: stop auto-scroll from yanking the view while reading older messages

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -57,6 +57,11 @@
 
   <!-- Composer -->
   <div id="composer">
+    <!-- Shown when new content streams in below while the user has scrolled up to read
+         older content — see updateJumpToLatest in chat.js. Lives here, not inside
+         #messages, so it floats above the composer's top edge rather than scrolling
+         away with the transcript it's meant to be seen over. -->
+    <div id="jump-to-latest" onclick="scrollBottom(true)" title="Jump to latest">__DOWN__</div>
     <div id="usage-warn"></div>
     <div id="input-wrap">
       <!-- Thumbnails of pasted images awaiting send (per active tab). -->

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
@@ -169,7 +169,7 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
       finalizeThink(); curBody = null; curText = '';
       showWorking();
     }
-    scrollBottom();
+    scrollBottom(true);   // the user just answered this card — take them to what follows
   }
 
   // Middle "remember" option is contextual: its label comes from the CLI's own
@@ -274,14 +274,14 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     if (window._answerQuestion) window._answerQuestion(reqId, JSON.stringify(answers));
     clearBottomCard();
     const summary = answers.map(a => questions.length > 1 ? (a.header + ': ' + a.answer) : a.answer).join('\n');
-    addAnswered(summary, pane); startFreshTurn(); scrollBottom();
+    addAnswered(summary, pane); startFreshTurn(); scrollBottom(true);   // user just answered
   }
   function cancel() {
     if (resolved) return; resolved = true;
     document.removeEventListener('keydown', onKey, true);
     resolveDot(true);
     if (window._answerQuestion) window._answerQuestion(reqId, '[]');
-    clearBottomCard(); scrollBottom();
+    clearBottomCard(); scrollBottom(true);   // user just dismissed the card
   }
 
   function render() {

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -17,17 +17,27 @@ function isNearBottom() {
   if (scrollable <= SCROLL_BOTTOM_SLOP) return true;   // nothing to scroll
   return scrollable - messagesEl.scrollTop <= SCROLL_BOTTOM_SLOP;
 }
-// Whether the view should keep following new content as it streams in. This is
-// STATE, not a per-call measurement: scrollHeight forces a synchronous layout flush
-// the instant it's read, so by the time scrollBottom() below could measure anything
-// the just-appended content is already counted, making one big chunk (a code fence,
-// a whole tool-result block — none of this streams in byte-sized pieces) indistinguishable
-// from the user having scrolled up. Measuring only ever happens in the 'scroll'
-// listener (the user's own wheel/drag) and, explicitly, right after scrollBottom's
-// own scrollTop write below — that write is a NO-OP (and so fires no 'scroll' event)
-// whenever the view is already sitting at that same position, which is exactly the
-// state a stale-false followTail plus a since-arrived resize back to the bottom can
-// produce; relying on the event alone would leave followTail stuck at false forever.
+// Whether the ACTIVE tab's view should keep following new content as it streams
+// in. This is STATE, not a per-call measurement: scrollHeight forces a synchronous
+// layout flush the instant it's read, so by the time scrollBottom() below could
+// measure anything the just-appended content is already counted, making one big
+// chunk (a code fence, a whole tool-result block — none of this streams in
+// byte-sized pieces) indistinguishable from the user having scrolled up. Measuring
+// only ever happens in the 'scroll' listener (the user's own wheel/drag) and,
+// explicitly, right after scrollBottom's own scrollTop write below — that write is
+// a NO-OP (and so fires no 'scroll' event) whenever the view is already sitting at
+// that same position, which is exactly the state a stale-false followTail plus a
+// since-arrived resize back to the bottom can produce; relying on the event alone
+// would leave followTail stuck at false forever.
+//
+// Kept as ONE module global describing whichever tab is currently on screen (like
+// curTurn/curBody etc. — see loadRender's comment in tabs.js) rather than always
+// reading activeTab().followTail, since #messages is one shared scroll container:
+// only the active tab's position is ever meaningfully "current". switchTab saves
+// this (and the raw scrollTop, since "was scrolled up" alone doesn't say how far —
+// a background pane's scrollTop isn't preserved by the DOM on its own) onto the
+// outgoing Tab and restores the incoming one's, the same pattern already used for
+// each tab's composer draft.
 let followTail = true;
 /**
  * @param {boolean} [force] Jump to the bottom even if the user scrolled up to read

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -23,9 +23,11 @@ function isNearBottom() {
 // the just-appended content is already counted, making one big chunk (a code fence,
 // a whole tool-result block — none of this streams in byte-sized pieces) indistinguishable
 // from the user having scrolled up. Measuring only ever happens in the 'scroll'
-// listener, which fires from the user's own wheel/drag AND from scrollBottom's own
-// scrollTop write below — and that write always lands exactly at the bottom, so it
-// always re-arms followTail to true, which is the right value there regardless.
+// listener (the user's own wheel/drag) and, explicitly, right after scrollBottom's
+// own scrollTop write below — that write is a NO-OP (and so fires no 'scroll' event)
+// whenever the view is already sitting at that same position, which is exactly the
+// state a stale-false followTail plus a since-arrived resize back to the bottom can
+// produce; relying on the event alone would leave followTail stuck at false forever.
 let followTail = true;
 /**
  * @param {boolean} [force] Jump to the bottom even if the user scrolled up to read
@@ -38,14 +40,24 @@ function scrollBottom(force) {
   if (workingEl && workingEl.parentNode) workingEl.parentNode.appendChild(workingEl); // keep last
   // Don't yank the visible view to the bottom for a BACKGROUND tab's stream — only
   // the active tab's pane is on screen, so a background render must not scroll it.
-  if (rtab && rtab !== activeTab()) return;
+  // force is a deliberate action ON THE ACTIVE TAB ITSELF (send, answer a card,
+  // click the jump-to-latest arrow) — it must bypass this, or a background tab
+  // that streamed anything since the last switch leaves rtab stale and silently
+  // defeats every one of those actions on the tab actually on screen.
+  if (!force && rtab && rtab !== activeTab()) return;
   if (!force && !followTail) { updateJumpToLatest(); return; }
   messagesEl.scrollTop = messagesEl.scrollHeight;
+  // Set directly rather than left to the 'scroll' event this write may fire: if the
+  // view is already sitting at the bottom (e.g. this is a force call arriving while
+  // followTail is stale-false), the write above is a no-op and no event fires —
+  // leaving followTail stuck false and the arrow visibly unable to fix itself even
+  // though scrollBottom(true) just ran and did put the view at the true bottom.
+  followTail = true;
   updateJumpToLatest();
 }
 // Shows the button once the user has scrolled away from the tail (followTail false),
-// hides it once they're following again — whether that's from clicking it
-// (scrollBottom(true) re-arms followTail via the scroll event its own write fires)
+// hides it once they're following again — whether that's from clicking it (scrollBottom
+// sets followTail directly, not relying on the scroll event its own write may not fire)
 // or scrolling back down themselves (the listener below).
 const jumpToLatestEl = document.getElementById('jump-to-latest');
 function updateJumpToLatest() {

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -6,13 +6,52 @@ let curTurn = null, curBody = null, curText = '';
 let curThink = null, curThinkText = '', thinkStart = 0, turnStart = 0;
 
 function clearWelcome(pane) { if (!pane) return; const w = pane.querySelector('.welcome'); if (w) w.remove(); }
-function scrollBottom() {
+// How far from the true bottom still counts as "at the bottom" for the purpose of
+// (re-)arming followTail below — has to clear the viewport settling on first render
+// (scrollHeight starts equal to clientHeight before any content), not a streamed
+// chunk's height. A big chunk arriving is NOT what this threshold has to survive:
+// followTail decides that by staying whatever it last was, not by re-measuring.
+const SCROLL_BOTTOM_SLOP = 4;
+function isNearBottom() {
+  const scrollable = messagesEl.scrollHeight - messagesEl.clientHeight;
+  if (scrollable <= SCROLL_BOTTOM_SLOP) return true;   // nothing to scroll
+  return scrollable - messagesEl.scrollTop <= SCROLL_BOTTOM_SLOP;
+}
+// Whether the view should keep following new content as it streams in. This is
+// STATE, not a per-call measurement: scrollHeight forces a synchronous layout flush
+// the instant it's read, so by the time scrollBottom() below could measure anything
+// the just-appended content is already counted, making one big chunk (a code fence,
+// a whole tool-result block — none of this streams in byte-sized pieces) indistinguishable
+// from the user having scrolled up. Measuring only ever happens in the 'scroll'
+// listener, which fires from the user's own wheel/drag AND from scrollBottom's own
+// scrollTop write below — and that write always lands exactly at the bottom, so it
+// always re-arms followTail to true, which is the right value there regardless.
+let followTail = true;
+/**
+ * @param {boolean} [force] Jump to the bottom even if the user scrolled up to read
+ *   older content — for a deliberate action of theirs (sending a message, answering
+ *   a permission prompt) where snapping back down is expected, not a surprise.
+ *   Streamed content omits this so reading history isn't interrupted every time a
+ *   chunk arrives; see updateJumpToLatest for how they get back down themselves.
+ */
+function scrollBottom(force) {
   if (workingEl && workingEl.parentNode) workingEl.parentNode.appendChild(workingEl); // keep last
   // Don't yank the visible view to the bottom for a BACKGROUND tab's stream — only
   // the active tab's pane is on screen, so a background render must not scroll it.
   if (rtab && rtab !== activeTab()) return;
+  if (!force && !followTail) { updateJumpToLatest(); return; }
   messagesEl.scrollTop = messagesEl.scrollHeight;
+  updateJumpToLatest();
 }
+// Shows the button once the user has scrolled away from the tail (followTail false),
+// hides it once they're following again — whether that's from clicking it
+// (scrollBottom(true) re-arms followTail via the scroll event its own write fires)
+// or scrolling back down themselves (the listener below).
+const jumpToLatestEl = document.getElementById('jump-to-latest');
+function updateJumpToLatest() {
+  if (jumpToLatestEl) jumpToLatestEl.classList.toggle('show', !followTail);
+}
+messagesEl.addEventListener('scroll', () => { followTail = isNearBottom(); updateJumpToLatest(); });
 /**
  * @param {string} text @param {string|null} [ctx] context-chip label (file:lines)
  * @param {{url: string, name: string, w: number, h: number}[]} [images] pasted-image chips
@@ -47,7 +86,7 @@ function addUserMessage(text, ctx, images, id) {
     box.appendChild(body);
   }
   turn.appendChild(box); pane.appendChild(turn);
-  scrollBottom();
+  scrollBottom(true);   // the user just sent this — take them to it even if they'd scrolled up
 }
 // Lazily create the assistant turn — only when real content (text or a tool)
 // arrives. While Claude is just "thinking", nothing but the working sunburst shows.

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
@@ -39,7 +39,8 @@ const ICONS = {
   SPARK: '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l1.6 6.4L20 10l-6.4 1.6L12 18l-1.6-6.4L4 10l6.4-1.6z"/></svg>',
   BRAIN: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M9 3a3 3 0 0 0-3 3 3 3 0 0 0-1 5.8A3 3 0 0 0 7 17a2.5 2.5 0 0 0 5 .5V5a2 2 0 0 0-3-2zM15 3a3 3 0 0 1 3 3 3 3 0 0 1 1 5.8A3 3 0 0 1 17 17a2.5 2.5 0 0 1-5 .5"/></svg>',
   USER: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="8" r="3.5"/><path d="M5 20a7 7 0 0 1 14 0"/></svg>',
-  ZOOM: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3M8 11h6M11 8v6"/></svg>'
+  ZOOM: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3M8 11h6M11 8v6"/></svg>',
+  DOWN: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M6 13l6 6 6-6"/></svg>'
 };
 /* substitute __NAME__ placeholders */
 document.body.innerHTML = document.body.innerHTML.replace(/__([A-Z]+)__/g, (m, k) => ICONS[k] || m);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -19,6 +19,10 @@
  * @property {boolean} [compacting]   /compact (or auto-compact) running — gerund pinned to "Compacting…"
  * @property {Object}  [_r]           parked render globals while another tab is loaded (see loadRender)
  * @property {HTMLElement|null} [_compEl] latest "Compacted chat" element awaiting its summary body
+ * @property {boolean} [followTail] whether #messages should auto-scroll to new content
+ *   for THIS tab; undefined (a brand-new tab) means caught-up, same as true (see chat.js)
+ * @property {number} [scrollTop] this tab's own #messages.scrollTop, saved on switch-away
+ *   since #messages is one shared scroll container — undefined means "at the bottom"
  */
 /** @type {Tab[]} */
 let tabs = [], activeId = null, tabSeq = 0;
@@ -90,10 +94,19 @@ function createTab(opts) {
   return tabs[tabs.length - 1];
 }
 function switchTab(id) {
-  // Each tab keeps its own unsent draft: stash the composer into the outgoing tab,
-  // then restore the incoming tab's draft so drafts don't bleed across tabs.
+  // Each tab keeps its own unsent draft, and its own scroll-follow state: stash the
+  // composer + #messages is ONE shared scroll container (only the active tab's pane
+  // is ever display:'' at a time), so a background pane's scroll position isn't
+  // preserved by the DOM on its own — followTail/scrollTop are saved onto the
+  // outgoing tab here, the same pattern as the draft, or switching away and back
+  // always resets to caught-up-at-the-bottom regardless of where the user had
+  // scrolled to.
   const prev = tabById(activeId);
-  if (prev && prev.id !== id) prev.draft = input.value;
+  if (prev && prev.id !== id) {
+    prev.draft = input.value;
+    prev.followTail = followTail;
+    prev.scrollTop = messagesEl.scrollTop;
+  }
   activeId = id;
   tabs.forEach(t => { t.pane.style.display = (t.id === id) ? '' : 'none'; });
   const t = activeTab();
@@ -109,18 +122,20 @@ function switchTab(id) {
   if (typeof syncComposer === 'function') syncComposer();           // send/stop reflects THIS tab
   try { if (window._activeTab) window._activeTab(id); } catch (e) {} // status bar follows active tab
   renderTabs();
-  // Not scrollBottom(true): this tab is now the active one and always jumps to its
-  // own bottom regardless of rtab, which scrollBottom's guard would otherwise
-  // wrongly apply here too.
-  messagesEl.scrollTop = messagesEl.scrollHeight;
-  // followTail is reset directly rather than left to the 'scroll' event this write
-  // may fire: when the incoming tab's content is already shorter than the viewport,
-  // scrollTop is already 0 and the assignment above is a no-op, so no 'scroll' event
-  // fires — leaving followTail at whatever the PREVIOUS tab last set it to (false,
-  // if that tab had been scrolled up) and silently disabling auto-scroll on this
-  // tab for the rest of its life. Always true here: a fresh switch always starts
-  // caught up, matching the jump this function just performed.
-  followTail = true;
+  // Restore THIS tab's own remembered state rather than always jumping to the
+  // bottom: a brand-new tab (followTail/scrollTop both undefined) defaults to
+  // caught-up, matching the previous always-jump behavior; a tab last left
+  // scrolled up reopens at the same spot instead of silently snapping down and
+  // hiding exactly the earlier content the user had scrolled up to read. Set
+  // directly rather than left to the 'scroll' event this scrollTop write may
+  // fire — restoring a position the container happens to already be at (e.g. two
+  // tabs both left scrolled to their own top) is a no-op and fires no event,
+  // which would otherwise leave followTail stuck at whatever the PREVIOUS tab
+  // left it as. Not scrollBottom(true) for the followTail:true case: this tab is
+  // now the active one and always jumps to its own bottom regardless of rtab,
+  // which scrollBottom's background-tab guard would otherwise wrongly apply here.
+  followTail = t.followTail !== false;
+  messagesEl.scrollTop = followTail ? messagesEl.scrollHeight : (t.scrollTop || 0);
   if (typeof updateJumpToLatest === 'function') updateJumpToLatest();
 }
 /* Loads a tab's stored model/effort/thinking/permission-mode into the composer UI
@@ -294,6 +309,12 @@ function clearSession() {
   t.compacting = false;
   t.downgradeWarned = null;
   t.pane.innerHTML = '';
+  // The old transcript's scroll state is meaningless against an emptied pane — left
+  // alone, a scrolled-up t.scrollTop would reopen the fresh conversation scrolled
+  // into blank space (with the jump arrow showing) the next time this tab is
+  // switched to. t is the active tab, so the module global needs resetting too.
+  t.followTail = true; t.scrollTop = 0;
+  followTail = true;
   document.getElementById('convo-title').textContent = t.title;
   renderTabs();
   if (typeof renderPendingImages === 'function') renderPendingImages();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -109,12 +109,18 @@ function switchTab(id) {
   if (typeof syncComposer === 'function') syncComposer();           // send/stop reflects THIS tab
   try { if (window._activeTab) window._activeTab(id); } catch (e) {} // status bar follows active tab
   renderTabs();
+  // Not scrollBottom(true): this tab is now the active one and always jumps to its
+  // own bottom regardless of rtab, which scrollBottom's guard would otherwise
+  // wrongly apply here too.
   messagesEl.scrollTop = messagesEl.scrollHeight;
-  // Not scrollBottom(true): its rtab !== activeTab() guard exists specifically to
-  // keep a background stream from yanking the view on a tab switch, so it would
-  // wrongly bail here too. This tab is now the active one and always jumps to its
-  // own bottom regardless — but the button (armed by a PRIOR tab's streaming) needs
-  // telling this new view is already there, or it would show over an at-rest tab.
+  // followTail is reset directly rather than left to the 'scroll' event this write
+  // may fire: when the incoming tab's content is already shorter than the viewport,
+  // scrollTop is already 0 and the assignment above is a no-op, so no 'scroll' event
+  // fires — leaving followTail at whatever the PREVIOUS tab last set it to (false,
+  // if that tab had been scrolled up) and silently disabling auto-scroll on this
+  // tab for the rest of its life. Always true here: a fresh switch always starts
+  // caught up, matching the jump this function just performed.
+  followTail = true;
   if (typeof updateJumpToLatest === 'function') updateJumpToLatest();
 }
 /* Loads a tab's stored model/effort/thinking/permission-mode into the composer UI

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -110,6 +110,12 @@ function switchTab(id) {
   try { if (window._activeTab) window._activeTab(id); } catch (e) {} // status bar follows active tab
   renderTabs();
   messagesEl.scrollTop = messagesEl.scrollHeight;
+  // Not scrollBottom(true): its rtab !== activeTab() guard exists specifically to
+  // keep a background stream from yanking the view on a tab switch, so it would
+  // wrongly bail here too. This tab is now the active one and always jumps to its
+  // own bottom regardless — but the button (armed by a PRIOR tab's streaming) needs
+  // telling this new view is already there, or it would show over an at-rest tab.
+  if (typeof updateJumpToLatest === 'function') updateJumpToLatest();
 }
 /* Loads a tab's stored model/effort/thinking/permission-mode into the composer UI
    + status bar. */

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
@@ -24,6 +24,21 @@
 #messages::-webkit-scrollbar-thumb { background: var(--scrollbar); border-radius: 5px; border: 2px solid var(--bg); }
 #messages::-webkit-scrollbar-track { background: transparent; }
 
+/* Floats just above #composer's top edge, shown only while streamed content is
+   arriving below the user's scroll position (see updateJumpToLatest in chat.js).
+   Lives inside #composer (layout.css gives it position: relative) rather than
+   #messages, which is the scroll container — an absolutely-positioned child of
+   THAT would scroll away with the transcript instead of staying put over it.
+   Anchored to the composer's top rather than a fixed screen position so it tracks
+   correctly as the composer grows (textarea auto-grow, pending-image strip). */
+#jump-to-latest { display: none; position: absolute; left: 50%; top: 0; z-index: 5;
+  transform: translate(-50%, calc(-100% - 8px)); width: 30px; height: 30px; border-radius: 50%;
+  align-items: center; justify-content: center; cursor: pointer;
+  background: var(--menu-bg); color: var(--fg-soft); border: 1px solid var(--border);
+  box-shadow: 0 2px 6px rgba(0,0,0,.3); }
+#jump-to-latest.show { display: flex; }
+#jump-to-latest:hover { color: var(--fg); border-color: var(--accent-dim); }
+
 .turn { position: relative; margin: 10px 0; }
 /* First bubble in a conversation gets breathing room below the title header. */
 .pane > .turn:first-child { margin-top: 18px; }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
@@ -91,7 +91,10 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 
 
 /* ── Composer ────────────────────────────────────────────── */
-#composer { flex-shrink: 0; padding: 8px 14px 12px; }
+/* position: relative so #jump-to-latest (chat.css) can anchor to this element's
+   top edge rather than the page's; nothing else inside #composer is absolutely
+   positioned, so this doesn't change any other element's containing block. */
+#composer { position: relative; flex-shrink: 0; padding: 8px 14px 12px; }
 /* Floats OVER the transcript at the composer's position (composer hides while a
    card is up). The transcript never reflows; showBottomCard reserves matching
    bottom padding in #messages so the last message can scroll above the card. */


### PR DESCRIPTION
## Motivation

While Claude is working, the transcript unconditionally jumps to the bottom on every streamed chunk, tool result, and turn boundary. That's the right default most of the time — but it makes it impossible to scroll up and read an earlier part of the conversation while a response is still streaming: every few seconds the view gets yanked back down out from under you, regardless of where you'd scrolled to.

## Design

The transcript should auto-scroll only while the user is actually following along at the bottom, and stop the moment they scroll away to read something else — resuming automatically only once they scroll back down themselves (or take some other action that implies they want to be at the bottom, like sending a message).

`scrollBottom()` (the single choke point every render path already went through) now tracks this as explicit state — `followTail` — updated from `#messages`' own `scroll` event rather than measured fresh on every call. That distinction matters: reading `scrollHeight` forces a synchronous layout flush that already includes whatever content was just appended, so a per-call "distance from bottom" measurement can't tell a large chunk arriving (a code fence, a whole tool-result block — none of this streams in byte-sized pieces) apart from the user having scrolled up. Tracking it as state sidesteps that entirely: the scroll listener also fires from `scrollBottom()`'s own `scrollTop` write, which always lands exactly at the bottom, so it re-arms itself correctly for free.

While auto-scroll is suppressed, a small "jump to latest" button appears above the composer so new content arriving isn't silently missed. Clicking it, or scrolling back down manually, resumes following.

A handful of call sites that scroll in response to a deliberate user action — sending a message, answering a permission or question card — pass `scrollBottom(true)` to jump down regardless of the current scroll position, matching the existing behavior for those specifically. A new permission/question card raised by Claude also still forces the view to the bottom unconditionally (unchanged, pre-existing behavior) since it's functionally blocking — the session can't proceed until it's answered, so surfacing it takes priority over an in-progress read.

## What it actually does

- Reading old messages while Claude streams: the view holds still, undisturbed.
- New content arrives while you're scrolled up: a small button appears above the composer instead of yanking the view down.
- Click that button, or scroll back down yourself: auto-follow resumes and the button disappears.
- Send a message while scrolled up: the view snaps to the bottom (you just acted, so being taken to what happens next is expected).
- Answer a permission/question card: same — snaps to the bottom.
- Claude raises a new card asking for input: the view jumps to it regardless of where you were reading, since the session is paused until you answer.
- A fresh or short conversation, or switching tabs: no stray button ever shows.

## Testing

Verified interactively (build via PDE `site.xml` → Build All → local Install New Software, same as issue #97's fix):
- Streaming a response containing a code block/tool result while at the bottom keeps following throughout (regression check for the large-chunk case above).
- Scrolling up mid-stream holds the view and shows the button; clicking it or scrolling back down resumes following.
- Sending a message while scrolled up snaps to the bottom.
- A fresh/short conversation never shows the button.
- Switching tabs while the button is showing clears it.