### PR TITLE
Add preferences for the permission/question/diff-review card timeouts

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
@@ -54,3 +54,21 @@ function clearBottomCard() {
   ensureWorking();
 }
 
+/* ---- server-side timeout dismissal ----
+   The Java side blocks on a per-card timeout preference and, on expiry, already
+   answers the CLI itself (deny / dismissed) before this ever runs — it just has
+   no way to tell the page the card it raised is now moot. Each card registers a
+   same-shape cleanup here (index by reqId) right before showBottomCard, and
+   unregisters it the moment it resolves itself (click / Enter / Esc) so a click
+   racing the timeout can't double-fire. Java invokes dismissTimedOutCard via
+   browser.execute once its future.get(...) times out. */
+const pendingCardTimeouts = new Map();  // reqId -> () => void
+function registerCardTimeout(reqId, onTimedOut) { pendingCardTimeouts.set(reqId, onTimedOut); }
+function unregisterCardTimeout(reqId) { pendingCardTimeouts.delete(reqId); }
+window.dismissTimedOutCard = function(reqId) {
+  const fn = pendingCardTimeouts.get(reqId);
+  if (!fn) return;   // already resolved by the user, or not this page's card
+  pendingCardTimeouts.delete(reqId);
+  fn();
+};
+

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
@@ -96,6 +96,7 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
   let resolved = false;
   function decide(d, msg) {
     if (resolved) return; resolved = true;
+    unregisterCardTimeout(reqId);
     document.removeEventListener('keydown', onKey, true);
     // Resolve the pending tool's dot: allow → green (finished), deny → red (rejected).
     if (pendingTool) {
@@ -217,6 +218,33 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
   }
   document.addEventListener('keydown', onKey, true);
 
+  // Java already answered "deny" to the CLI by the time this fires (its own
+  // future.get(...) timed out) — this is presentation-only cleanup, so it must
+  // NOT call window._decide again (that reqId is no longer pending on the Java
+  // side; a stray second answer would be sent for nothing).
+  registerCardTimeout(reqId, () => {
+    if (resolved) return; resolved = true;
+    document.removeEventListener('keydown', onKey, true);
+    if (pendingTool) {
+      pendingTool.classList.remove('pending');
+      const dot = pendingTool.querySelector('.dot');
+      if (dot) dot.className = 'dot red';
+      if (isPlan) {
+        const sub = document.createElement('div'); sub.className = 'tool-sub';
+        sub.textContent = planOutcomeText(true);
+        pendingTool.appendChild(sub);
+      }
+    }
+    clearBottomCard();
+    // addAnswered inserts a new sibling turn div; startFreshTurn must follow it
+    // (curTurn = null) or the CLI's continuation streams into the turn ABOVE this
+    // note instead of below it — the same pairing decide()'s message-deny branch
+    // uses, not the silent plain-deny branch (which inserts nothing).
+    addAnswered('(No response — the request timed out and was denied.)', pane);
+    startFreshTurn();
+    scrollBottom();
+  });
+
   showBottomCard(card);
 };
 
@@ -265,6 +293,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   }
   function finish() {
     if (resolved || !allAnswered()) return; resolved = true;
+    unregisterCardTimeout(reqId);
     document.removeEventListener('keydown', onKey, true);
     resolveDot(false);
     const answers = questions.map((q, i) => ({
@@ -278,6 +307,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   }
   function cancel() {
     if (resolved) return; resolved = true;
+    unregisterCardTimeout(reqId);
     document.removeEventListener('keydown', onKey, true);
     resolveDot(true);
     if (window._answerQuestion) window._answerQuestion(reqId, '[]');
@@ -347,6 +377,23 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     if (e.key === 'Escape' && (!document.activeElement || document.activeElement.tagName !== 'INPUT')) { e.preventDefault(); cancel(); }
   }
   document.addEventListener('keydown', onKey, true);
+
+  // Java already answered "[]" (dismissed) to the CLI by the time this fires — see
+  // the matching comment on the approval card's registerCardTimeout for why this
+  // must be presentation-only and never call window._answerQuestion again.
+  registerCardTimeout(reqId, () => {
+    if (resolved) return; resolved = true;
+    document.removeEventListener('keydown', onKey, true);
+    resolveDot(true);
+    clearBottomCard();
+    // Same pairing as finish(): addAnswered's new sibling turn div requires
+    // startFreshTurn right after it (see the matching comment on the approval
+    // card's timeout handler) so Claude's continuation lands below this note.
+    addAnswered('(No response — the question timed out and was dismissed.)', pane);
+    startFreshTurn();
+    scrollBottom();
+  });
+
   render(); showBottomCard(card);
 };
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -1,5 +1,9 @@
 package com.anthropic.claudecode.eclipse;
 
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
 public final class Constants {
 
     public static final String PLUGIN_ID = "com.anthropic.claudecode.eclipse";
@@ -29,6 +33,29 @@ public final class Constants {
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";
 
+    // ── Decision-card timeouts ───────────────────────────────────────────────
+    // How long each kind of blocking "waiting on the user" card (permission
+    // approval, AskUserQuestion, diff review) waits before giving up and
+    // resolving on its own. Each is one of TIMEOUT_MODE_DEFAULT/_NEVER/_CUSTOM
+    // plus a *_SECONDS value; TIMEOUT_MODE_DEFAULT reproduces the plugin's
+    // longstanding hardcoded 30-minute wait for that card.
+    public static final String PREF_APPROVAL_TIMEOUT_MODE = "approvalTimeoutMode";
+    public static final String PREF_APPROVAL_TIMEOUT_SECONDS = "approvalTimeoutSeconds";
+    public static final String PREF_QUESTION_TIMEOUT_MODE = "questionTimeoutMode";
+    public static final String PREF_QUESTION_TIMEOUT_SECONDS = "questionTimeoutSeconds";
+    public static final String PREF_DIFF_REVIEW_TIMEOUT_MODE = "diffReviewTimeoutMode";
+    public static final String PREF_DIFF_REVIEW_TIMEOUT_SECONDS = "diffReviewTimeoutSeconds";
+
+    /** Use the plugin's longstanding default wait (currently 30 minutes) for this card. */
+    public static final String TIMEOUT_MODE_DEFAULT = "default";
+    /** Wait indefinitely (in practice: a very long ceiling — see resolveTimeoutSeconds). */
+    public static final String TIMEOUT_MODE_NEVER = "never";
+    /** Wait exactly the paired *_SECONDS preference. */
+    public static final String TIMEOUT_MODE_CUSTOM = "custom";
+
+    /** The wait every decision-card timeout has always used, preserved as the default. */
+    public static final int DEFAULT_DECISION_TIMEOUT_SECONDS = 30 * 60;
+
     // ── Claude Terminal status bar (statusLine) ─────────────────────────────
     /** Master switch: inject the statusLine and show the per-tab status bar. */
     public static final String PREF_STATUSLINE_ENABLED = "statuslineEnabled";
@@ -49,6 +76,31 @@ public final class Constants {
     public static final String IMG_NEW_CLI_SESSION = "new_cli_session";
     public static final String IMG_SCROLL_LOCK = "scroll_lock";
     public static final String IMG_SESSION_HISTORY = "session_history";
+
+    /**
+     * A ceiling used for {@link #TIMEOUT_MODE_NEVER}: none of the three decision-card
+     * waits are guaranteed to be released early if their tab/view/editor closes while
+     * the card is pending (the CompletableFuture just sits there), so a truly unbounded
+     * {@code future.get()} could wedge that worker thread — and the CLI call it's
+     * servicing — forever. 30 days is "never" for any human waiting on a prompt, while
+     * still guaranteeing the thread eventually unblocks.
+     */
+    private static final long NEVER_TIMEOUT_SECONDS = TimeUnit.DAYS.toSeconds(30);
+
+    /**
+     * Resolves one of the three decision-card timeout preference pairs (mode + custom
+     * seconds) to the number of seconds to actually wait.
+     */
+    public static long resolveTimeoutSeconds(IPreferenceStore store, String modeKey, String secondsKey) {
+        String mode = store.getString(modeKey);
+        if (TIMEOUT_MODE_NEVER.equals(mode)) {
+            return NEVER_TIMEOUT_SECONDS;
+        }
+        if (TIMEOUT_MODE_CUSTOM.equals(mode)) {
+            return store.getInt(secondsKey);
+        }
+        return DEFAULT_DECISION_TIMEOUT_SECONDS;   // TIMEOUT_MODE_DEFAULT, or unrecognized/unset
+    }
 
     private Constants() {}
 }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/tools/OpenDiffTool.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/tools/OpenDiffTool.java
@@ -38,6 +38,8 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
 
+import com.anthropic.claudecode.eclipse.Activator;
+import com.anthropic.claudecode.eclipse.Constants;
 import com.anthropic.claudecode.eclipse.editor.UiHelper;
 import com.anthropic.claudecode.eclipse.mcp.McpTool;
 import com.anthropic.claudecode.eclipse.mcp.McpToolResult;
@@ -393,7 +395,11 @@ public class OpenDiffTool implements McpTool {
         // Block the MCP worker thread — Claude waits here until the diff is resolved.
         // The UI thread is free to process events (paint, respond to clicks, etc.).
         try {
-            McpToolResult result = decision.get(30, TimeUnit.MINUTES);
+            long timeoutSeconds = Constants.resolveTimeoutSeconds(
+                    Activator.getDefault().getPreferenceStore(),
+                    Constants.PREF_DIFF_REVIEW_TIMEOUT_MODE,
+                    Constants.PREF_DIFF_REVIEW_TIMEOUT_SECONDS);
+            McpToolResult result = decision.get(timeoutSeconds, TimeUnit.SECONDS);
             // After FILE_SAVED the CLI writes the file. Schedule a workspace refresh
             // so Eclipse picks up the change once the CLI write lands on disk.
             Display.getDefault().asyncExec(() -> refreshWorkspaceFile(filePath));

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -1713,7 +1713,11 @@ public class ClaudeGuiView extends ViewPart {
             }
         });
         try {
-            return future.get(30, TimeUnit.MINUTES);
+            long seconds = com.anthropic.claudecode.eclipse.Constants.resolveTimeoutSeconds(
+                    Activator.getDefault().getPreferenceStore(),
+                    com.anthropic.claudecode.eclipse.Constants.PREF_APPROVAL_TIMEOUT_MODE,
+                    com.anthropic.claudecode.eclipse.Constants.PREF_APPROVAL_TIMEOUT_SECONDS);
+            return future.get(seconds, TimeUnit.SECONDS);
         } catch (Exception e) {
             return "deny";
         } finally {
@@ -1754,7 +1758,11 @@ public class ClaudeGuiView extends ViewPart {
             }
         });
         try {
-            return future.get(30, TimeUnit.MINUTES);
+            long seconds = com.anthropic.claudecode.eclipse.Constants.resolveTimeoutSeconds(
+                    Activator.getDefault().getPreferenceStore(),
+                    com.anthropic.claudecode.eclipse.Constants.PREF_QUESTION_TIMEOUT_MODE,
+                    com.anthropic.claudecode.eclipse.Constants.PREF_QUESTION_TIMEOUT_SECONDS);
+            return future.get(seconds, TimeUnit.SECONDS);
         } catch (Exception e) {
             return "[]";
         } finally {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -1718,6 +1719,13 @@ public class ClaudeGuiView extends ViewPart {
                     com.anthropic.claudecode.eclipse.Constants.PREF_APPROVAL_TIMEOUT_MODE,
                     com.anthropic.claudecode.eclipse.Constants.PREF_APPROVAL_TIMEOUT_SECONDS);
             return future.get(seconds, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            // The card is still on screen (the user never answered): the JS side has
+            // no idea we're about to give up on its behalf, so tell it to tear the
+            // card down and show what happened — otherwise it sits there forever
+            // even though the CLI has already moved on with this "deny".
+            dismissTimedOutCard(reqId);
+            return "deny";
         } catch (Exception e) {
             return "deny";
         } finally {
@@ -1727,6 +1735,21 @@ public class ClaudeGuiView extends ViewPart {
                 catch (Exception ignored) {}
             }
         }
+    }
+
+    /** Tells the page a card's Java-side wait timed out, so it can dismiss the
+     *  card presentation-only — the CLI already has its answer (see the
+     *  matching JS comment on registerCardTimeout in cards.js). Safe to call for
+     *  a card that already resolved itself (window.dismissTimedOutCard no-ops). */
+    private static void dismissTimedOutCard(String reqId) {
+        ClaudeGuiView view = active;
+        if (view == null || view.browser == null) return;
+        final String rid = esc(reqId);
+        Display.getDefault().asyncExec(() -> {
+            if (view.browser != null && !view.browser.isDisposed() && view.pageLoaded) {
+                view.browser.execute("window.dismissTimedOutCard && window.dismissTimedOutCard('" + rid + "')");
+            }
+        });
     }
 
     /**
@@ -1763,6 +1786,9 @@ public class ClaudeGuiView extends ViewPart {
                     com.anthropic.claudecode.eclipse.Constants.PREF_QUESTION_TIMEOUT_MODE,
                     com.anthropic.claudecode.eclipse.Constants.PREF_QUESTION_TIMEOUT_SECONDS);
             return future.get(seconds, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            dismissTimedOutCard(reqId);   // see the matching comment in requestApproval
+            return "[]";
         } catch (Exception e) {
             return "[]";
         } finally {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -27,6 +27,13 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_HTTPS_PROXY, "");
         store.setDefault(Constants.PREF_NO_PROXY, "");
 
+        store.setDefault(Constants.PREF_APPROVAL_TIMEOUT_MODE, Constants.TIMEOUT_MODE_DEFAULT);
+        store.setDefault(Constants.PREF_APPROVAL_TIMEOUT_SECONDS, Constants.DEFAULT_DECISION_TIMEOUT_SECONDS);
+        store.setDefault(Constants.PREF_QUESTION_TIMEOUT_MODE, Constants.TIMEOUT_MODE_DEFAULT);
+        store.setDefault(Constants.PREF_QUESTION_TIMEOUT_SECONDS, Constants.DEFAULT_DECISION_TIMEOUT_SECONDS);
+        store.setDefault(Constants.PREF_DIFF_REVIEW_TIMEOUT_MODE, Constants.TIMEOUT_MODE_DEFAULT);
+        store.setDefault(Constants.PREF_DIFF_REVIEW_TIMEOUT_SECONDS, Constants.DEFAULT_DECISION_TIMEOUT_SECONDS);
+
         // Claude Terminal status bar (statusLine) — on by default, except the thinking segment.
         store.setDefault(Constants.PREF_STATUSLINE_ENABLED, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_MODEL, true);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -8,6 +8,7 @@ import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.IntegerFieldEditor;
+import org.eclipse.jface.preference.RadioGroupFieldEditor;
 import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.swt.SWT;
@@ -25,6 +26,10 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
 
     private BooleanFieldEditor statuslineEnabled;
     private final List<FieldEditor> statuslineDependents = new ArrayList<>();
+
+    /** One decision-card timeout's mode radio group + its dependent custom-seconds field. */
+    private record TimeoutFieldPair(RadioGroupFieldEditor mode, IntegerFieldEditor seconds) {}
+    private final List<TimeoutFieldPair> timeoutFields = new ArrayList<>();
 
     public ClaudePreferencePage() {
         super(GRID);
@@ -149,6 +154,55 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 Constants.PREF_NO_PROXY,
                 "NO_PROXY:",
                 getFieldEditorParent()));
+
+        Label timeoutSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);
+        timeoutSeparator.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+
+        Label timeoutLabel = new Label(getFieldEditorParent(), SWT.NONE);
+        timeoutLabel.setText("Decision card timeouts: how long an unanswered card waits before Claude\n"
+                + "Code assumes an answer (a denial, for approval/question cards) and continues\n"
+                + "on its own. Applies to cards raised after the change; a card already waiting\n"
+                + "keeps the timeout that was in effect when it appeared:");
+        timeoutLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+
+        addTimeoutFields("Permission approval:", Constants.PREF_APPROVAL_TIMEOUT_MODE,
+                Constants.PREF_APPROVAL_TIMEOUT_SECONDS);
+        addTimeoutFields("Ask-user question:", Constants.PREF_QUESTION_TIMEOUT_MODE,
+                Constants.PREF_QUESTION_TIMEOUT_SECONDS);
+        addTimeoutFields("Diff review:", Constants.PREF_DIFF_REVIEW_TIMEOUT_MODE,
+                Constants.PREF_DIFF_REVIEW_TIMEOUT_SECONDS);
+    }
+
+    /**
+     * Adds one decision-card timeout's mode radio group + custom-seconds field,
+     * under a sub-heading naming which card it governs.
+     */
+    private void addTimeoutFields(String heading, String modeKey, String secondsKey) {
+        Label heading_ = new Label(getFieldEditorParent(), SWT.NONE);
+        heading_.setText(heading);
+        heading_.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+
+        RadioGroupFieldEditor mode = new RadioGroupFieldEditor(
+                modeKey,
+                "",
+                1,
+                new String[][] {
+                        { "Default (30 minutes)", Constants.TIMEOUT_MODE_DEFAULT },
+                        { "Never — wait indefinitely for an answer", Constants.TIMEOUT_MODE_NEVER },
+                        { "Custom:", Constants.TIMEOUT_MODE_CUSTOM },
+                },
+                getFieldEditorParent(),
+                true);
+        addField(mode);
+
+        IntegerFieldEditor seconds = new IntegerFieldEditor(
+                secondsKey,
+                "Custom timeout (seconds):",
+                getFieldEditorParent());
+        seconds.setValidRange(1, Integer.MAX_VALUE / 2);
+        addField(seconds);
+
+        timeoutFields.add(new TimeoutFieldPair(mode, seconds));
     }
 
     private void addStatuslineDependent(FieldEditor editor) {
@@ -167,16 +221,29 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         }
     }
 
+    private void updateTimeoutSecondsEnabled(TimeoutFieldPair pair) {
+        boolean custom = Constants.TIMEOUT_MODE_CUSTOM.equals(pair.mode().getSelectionValue());
+        pair.seconds().setEnabled(custom, getFieldEditorParent());
+    }
+
+    private void updateAllTimeoutSecondsEnabled() {
+        for (TimeoutFieldPair pair : timeoutFields) {
+            updateTimeoutSecondsEnabled(pair);
+        }
+    }
+
     @Override
     protected void initialize() {
         super.initialize();
         updateStatuslineDependentsEnabled();
+        updateAllTimeoutSecondsEnabled();
     }
 
     @Override
     protected void performDefaults() {
         super.performDefaults();
         updateStatuslineDependentsEnabled();
+        updateAllTimeoutSecondsEnabled();
     }
 
     @Override
@@ -185,6 +252,13 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         if (event.getSource() == statuslineEnabled
                 && FieldEditor.VALUE.equals(event.getProperty())) {
             updateStatuslineDependentsEnabled();
+        }
+        if (FieldEditor.VALUE.equals(event.getProperty())) {
+            for (TimeoutFieldPair pair : timeoutFields) {
+                if (event.getSource() == pair.mode()) {
+                    updateTimeoutSecondsEnabled(pair);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What this does

A permission-approval card, an AskUserQuestion card, or a diff left open for review that goes unanswered for a long time silently resolves itself (a denial, for approval/question cards) and Claude continues on its own. This adds a preference for each of the three, so the wait is configurable instead of a hardcoded 30 minutes:

- **Preferences page**: three Default (30 min, unchanged) / Never / Custom-seconds groups — Permission approval, Ask-user question, Diff review.
- Read live, at the moment each card is raised, so a change applies to the next card without restarting Eclipse, the plugin, or the chat session. A card already on screen keeps the timeout that was in effect when it appeared.
- "Never" resolves to a 30-day ceiling rather than a truly unbounded wait, since an abandoned card's future is never otherwise released — this guarantees the worker thread it's blocking eventually unblocks either way.
- The embedded Terminal view is out of scope: it runs the CLI directly in a real TTY, so its permission prompts are the CLI's own native UI with no plugin-side hook to intercept.

Also fixes a bug this surfaced: when the Java-side wait times out, the CLI gets its answer correctly, but the browser-side card was never told to close — it stayed on screen indefinitely even though Claude had already moved on. Fixed with a small registry (`carddock.js`) that tears the card down and leaves a "(No response — timed out)" note in the transcript, without re-answering the CLI a second time.

Pure Java/JS change — no native (Rust) rebuild needed, so this applies on every platform as soon as it's built.

## Testing

Verified manually: set a 10-second custom timeout, triggered a prompt, left it unanswered, confirmed the card clears itself with the timeout note and Claude's continuation renders correctly below it.
