### PR TITLE
Allow Shift+Enter for a newline in the AskUserQuestion Other field

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
@@ -327,14 +327,24 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     otxt.appendChild(Object.assign(document.createElement('div'), { className: 'q-otitle', textContent: 'Other' }));
     orow.appendChild(otxt);
     orow.onclick = () => { state[activeQ].choice = 'other'; render();
-      setTimeout(() => { const i = card.querySelector('.q-other-in input'); if (i) i.focus(); }, 0); };
+      setTimeout(() => { const i = card.querySelector('.q-other-in textarea'); if (i) i.focus(); }, 0); };
     card.appendChild(orow);
     if (state[activeQ].choice === 'other') {
       const oin = document.createElement('div'); oin.className = 'q-other-in';
-      const inp = document.createElement('input'); inp.type = 'text'; inp.placeholder = 'Type your answer'; inp.value = state[activeQ].other;
-      inp.oninput = () => { state[activeQ].other = inp.value; submit.classList.toggle('ready', allAnswered()); };
-      inp.onkeydown = (e) => { e.stopPropagation(); if (e.key === 'Enter') { e.preventDefault(); finish(); } };
+      // textarea, not input: a single-line <input> has no notion of a newline at
+      // all, so Shift+Enter had nothing to fall through to. Mirrors the main
+      // composer (#input in ui.js) — auto-grow on input, Enter submits, Shift+Enter
+      // is left alone to insert a newline natively.
+      const inp = document.createElement('textarea'); inp.rows = 1; inp.placeholder = 'Type your answer'; inp.value = state[activeQ].other;
+      const grow = () => { inp.style.height = 'auto'; inp.style.height = Math.min(inp.scrollHeight, 160) + 'px'; };
+      inp.oninput = () => { state[activeQ].other = inp.value; submit.classList.toggle('ready', allAnswered()); grow(); };
+      inp.onkeydown = (e) => { e.stopPropagation(); if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); finish(); } };
       oin.appendChild(inp); card.appendChild(oin);
+      // render() re-seeds .value from saved state on every option click / question-tab
+      // switch, but oninput (where grow() normally runs) doesn't fire for that — size
+      // it once here too, or a revisited multi-line answer comes back collapsed to one
+      // row. Needs to be in the DOM first for scrollHeight to mean anything.
+      grow();
     }
     submit.className = 'q-submit' + (allAnswered() ? ' ready' : '');
     submit.innerHTML = '<span class="num">1</span><span>Submit answers</span>';
@@ -344,7 +354,14 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   }
   function onKey(e) {
     if (resolved) return;
-    if (e.key === 'Escape' && (!document.activeElement || document.activeElement.tagName !== 'INPUT')) { e.preventDefault(); cancel(); }
+    // Capture-phase on document: runs before the Other field's own onkeydown, so
+    // that handler's stopPropagation can't shield it — the tag check here is what
+    // has to do it. Must accept TEXTAREA too now that Other is one (was INPUT-only
+    // when it was a single-line <input>), or Escape while typing an answer
+    // dismisses the whole card and throws away what was typed.
+    const ae = document.activeElement;
+    const inField = ae && (ae.tagName === 'INPUT' || ae.tagName === 'TEXTAREA');
+    if (e.key === 'Escape' && !inField) { e.preventDefault(); cancel(); }
   }
   document.addEventListener('keydown', onKey, true);
   render(); showBottomCard(card);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/cards.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/cards.css
@@ -63,9 +63,10 @@
 .question-card .q-otitle { color: var(--fg); font-size: 12.5px; font-weight: 600; }
 .question-card .q-odesc { color: var(--fg-dim); font-size: 11.5px; line-height: 1.4; }
 .question-card .q-other-in { margin: 0 14px 6px 41px; }
-.question-card .q-other-in input { width: 100%; background: var(--bg-code); border: 1px solid var(--border);
-  border-radius: 6px; padding: 7px 10px; color: var(--fg); font-size: 12.5px; outline: none; font-family: inherit; }
-.question-card .q-other-in input:focus { border-color: var(--sel); }
+.question-card .q-other-in textarea { width: 100%; background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: 6px; padding: 7px 10px; color: var(--fg); font-size: 12.5px; outline: none; font-family: inherit;
+  resize: none; max-height: 160px; line-height: 1.4; }
+.question-card .q-other-in textarea:focus { border-color: var(--sel); }
 .question-card .q-submit { display: flex; align-items: center; gap: 8px; margin: 8px 14px 2px; padding: 9px 12px;
   border-radius: 6px; background: var(--bg-chip); color: var(--fg-dim); font-size: 12.5px; cursor: pointer; }
 .question-card .q-submit.ready { background: var(--sel); color: var(--on-accent); }


### PR DESCRIPTION
## What this does

The AskUserQuestion card's "Other" free-text field was a single-line `<input>`, so Shift+Enter had no newline to fall through to — unlike the main composer, which uses a `<textarea>` where that's native browser behavior.

Switches it to a `<textarea rows="1">` with the same auto-grow-on-input as the composer, and Enter-without-Shift submits (Shift+Enter now inserts a newline as expected).

Also fixes the card's Escape handler, which special-cased `tagName !== 'INPUT'` to avoid dismissing the whole card while typing an answer — needed the same allowance for `TEXTAREA` now, or Escape while composing a multi-line answer would cancel the card and discard what was typed.

## Testing

Verified manually: Shift+Enter inserts a newline, Enter submits, Escape with focus in the field no longer dismisses the card, and switching to another question tab and back shows multi-line text at full height.
