### PR TITLE
Fix approval/question cards getting lost when multiple tabs are active

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
@@ -40,6 +40,10 @@ function advisorCurrent() {
  *  once the user actually picks an advisor (nothing is echoed on cancel). */
 function openAdvisorCard(echoText) {
   closeMenus(); closeSlash();
+  // Opened synchronously by the user's own /advisor command — always the active
+  // tab, never a background stream tab (unlike onApprovalRequest/onAskQuestion,
+  // which are raised by a possibly-backgrounded tab's own CLI process).
+  const owner = activeTab();
   const OPTS = advisorOptions();
   const advisorChoice = advisorCurrent();
   const card = document.createElement('div'); card.className = 'decision advisor';
@@ -68,7 +72,7 @@ function openAdvisorCard(echoText) {
     resolved = true;
     document.removeEventListener('keydown', onKey, true);
     unregisterOverlayCancel();
-    clearBottomCard();
+    clearBottomCard(owner);
   }
   function cancel() { if (!resolved) done(); }
   function confirm(i) {
@@ -137,12 +141,8 @@ function openAdvisorCard(echoText) {
     if (n >= 1 && n <= OPTS.length) { e.preventDefault(); confirm(n - 1); }
   }
   document.addEventListener('keydown', onKey, true);
-  registerOverlayCancel(cancel, true);   // bottom card → tab-visibility guard applies
+  registerOverlayCancel(cancel, true, owner);   // bottom card → tab-visibility guard applies
 
-  showBottomCard(card);
-  // This card belongs to the tab it was opened from — never a background stream tab
-  // (showBottomCard defaults to rtab, which may be mid-stream elsewhere).
-  pendingCardOwner = activeTab();
-  renderBottomCard();
+  showBottomCard(card, owner);
 }
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
@@ -15,20 +15,28 @@ function padForBottomCard() {
 new ResizeObserver(() => {
   if (bottomCardEl.style.display === 'block') { padForBottomCard(); scrollBottom(); }
 }).observe(bottomCardEl);
-/* A pending card belongs to the conversation that raised it (its stream tab). It
-   only shows while THAT tab is active; switching away hides it (composer returns),
-   switching back re-shows it. */
-let pendingCard = null, pendingCardOwner = null;
-function showBottomCard(card) {
-  pendingCard = card;
-  pendingCardOwner = rtab || activeTab();   // set by loadRender in onApprovalRequest/onAskQuestion
+/* A pending card belongs to the conversation that raised it (its stream tab), and
+   is stored ON that Tab (Tab.pendingCard) rather than in one shared global — each
+   tab runs its own CLI process and can have its own card pending independently
+   (e.g. tab A is mid-AskUserQuestion when tab B's background process raises its
+   own approval prompt). A single shared slot would have the later card silently
+   evict the earlier one: the evicted tab's card vanishes from the DOM with no
+   cleanup (its keydown listener and timeout registration both leak, still armed
+   against a card no longer shown), and its Java-side future is orphaned — nothing
+   can ever answer it, so that tab hangs on its tool's "pending" state until the
+   timeout preference (or the user interrupting the session) ends it. Only shows
+   while its owning tab is active; switching away hides it (composer returns),
+   switching back re-shows THAT tab's own card, not whichever was raised last. */
+function showBottomCard(card, owner) {
+  owner.pendingCard = card;
   renderBottomCard();
 }
 function renderBottomCard() {
   const composer = document.getElementById('composer');
-  const show = pendingCard && pendingCardOwner && pendingCardOwner === activeTab();
-  if (show) {
-    if (bottomCardEl.firstChild !== pendingCard) { bottomCardEl.innerHTML = ''; bottomCardEl.appendChild(pendingCard); }
+  const t = activeTab();
+  const card = t && t.pendingCard;
+  if (card) {
+    if (bottomCardEl.firstChild !== card) { bottomCardEl.innerHTML = ''; bottomCardEl.appendChild(card); }
     bottomCardEl.style.display = 'block';
     composer.style.display = 'none';
     // Card only shows for the active tab → autoScroll, not scrollBottom, whose background
@@ -46,10 +54,11 @@ function renderBottomCard() {
     composer.style.display = '';
   }
 }
-function clearBottomCard() {
-  const owner = pendingCardOwner;
-  pendingCard = null; pendingCardOwner = null;
-  renderBottomCard();      // hides the card, restores the composer
+/** @param {Tab} owner the tab whose OWN card is being cleared — never inferred
+ *  from rtab/activeTab, so dismissing tab A's card can never touch tab B's. */
+function clearBottomCard(owner) {
+  if (owner) owner.pendingCard = null;
+  renderBottomCard();      // hides the card, restores the composer (if this was the active tab's)
   input.focus();
   // A blocking card (AskUserQuestion / approval) suspends the turn WITHOUT ending
   // it — dismissing the card resumes the same turn, so no onStreamStart fires to
@@ -71,7 +80,7 @@ function clearBottomCard() {
    advertise the truth instead of hardcoding "Esc". Empty means nothing is bound — the
    card then shows no hint at all rather than naming a key that does nothing. */
 let cancelHint = 'Esc';
-let activeCardCancel = null, activeCancelIsBottom = false;
+let activeCardCancel = null, activeCancelIsBottom = false, activeCancelOwner = null;
 
 /* Every hint on screen repaints itself when the binding changes, rather than waiting to be
    rebuilt. Java pushes a new label the moment Eclipse's BindingManager fires — switching
@@ -103,32 +112,43 @@ function cancelKeyName() { return cancelHint; }
 function cancelHintText() { return cancelHint ? cancelHint + ' to cancel' : ''; }
 
 /* Java-raised blocking cards: Java already activated the key context around its own
-   future.get(), so these must NOT notify it again. */
-function registerCardCancel(fn) { activeCardCancel = fn; activeCancelIsBottom = true; }
-function unregisterCardCancel() { activeCardCancel = null; activeCancelIsBottom = false; }
+   future.get(), so these must NOT notify it again. owner is the tab this card belongs
+   to (the same owner showBottomCard was given) — activeCardCancel is still ONE global
+   slot, so without it a card raised on a background tab would leave its cancel() as
+   the one that fires when the dismiss key is pressed over a DIFFERENT tab's own card. */
+function registerCardCancel(fn, owner) { activeCardCancel = fn; activeCancelIsBottom = true; activeCancelOwner = owner; }
+function unregisterCardCancel() { activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null; }
 
 /* Page-local overlays (advisor card, rewind picker, lightbox). Java cannot know these are
    open — nothing on its side raised them — so the page has to say so, or the key context
    never activates and the key stays dead however honest the hint is. _overlayOpen is
    edge-triggered on the Java side, so a missed unregister can only ever be one deep and the
-   next register/unregister corrects it. */
-function registerOverlayCancel(fn, isBottomCard) {
-  activeCardCancel = fn; activeCancelIsBottom = !!isBottomCard;
+   next register/unregister corrects it. owner: see registerCardCancel — only meaningful
+   when isBottomCard, since a non-bottom overlay isn't tab-owned. */
+function registerOverlayCancel(fn, isBottomCard, owner) {
+  activeCardCancel = fn; activeCancelIsBottom = !!isBottomCard; activeCancelOwner = owner || null;
   if (window._overlayOpen) window._overlayOpen(true);
 }
 function unregisterOverlayCancel() {
-  activeCardCancel = null; activeCancelIsBottom = false;
+  activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null;
   if (window._overlayOpen) window._overlayOpen(false);
 }
 
 window.cancelActiveCard = function() {
   if (!activeCardCancel) return;
   // Bottom cards only: one parked on a background tab must not vanish because a key was
-  // pressed over another conversation. Mirrors renderBottomCard's own visibility test.
+  // pressed over another conversation. Mirrors renderBottomCard's own visibility test,
+  // now split into two checks since each tab tracks its own pendingCard instead of one
+  // shared pendingCard/pendingCardOwner pair: the ACTIVE tab must actually have a card
+  // showing, AND it must be the same tab that registered this cancel — two different
+  // background tabs can each have their own card pending, so "some card is showing" is
+  // not enough on its own; it has to be THIS card's owner specifically, or switching to
+  // tab A while activeCardCancel is still tab B's would fire B's cancel from A's screen.
   // Overlays (rewind, lightbox) are not tab-owned, so the test does not apply to them.
-  if (activeCancelIsBottom && (!pendingCard || pendingCardOwner !== activeTab())) return;
+  const t = activeTab();
+  if (activeCancelIsBottom && (!t || !t.pendingCard || activeCancelOwner !== t)) return;
   const fn = activeCardCancel;
-  activeCardCancel = null; activeCancelIsBottom = false;
+  activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null;
   fn();
 };
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
@@ -63,6 +63,11 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
   const t = tabById(tabId);
   if (t && t.cancelled) { if (window._decide) window._decide(reqId, 'deny', ''); return; }  // stopped: auto-deny, no card
   if (t) loadRender(t);   // card belongs to this conversation
+  // The card's OWNER tab, for showBottomCard/clearBottomCard below — t if it
+  // resolved, else whatever loadRender last pointed at, same fallback order the
+  // pane lookup already used. Captured once so a later tab switch (rtab/activeTab
+  // changing) can't retarget which tab's card this decide() call clears.
+  const owner = t || rtab || activeTab();
   const pane = streamPane() || (activeTab() ? activeTab().pane : null);
   if (!pane) { if (window._decide) window._decide(reqId, 'deny', ''); return; }
   hideWorking();
@@ -158,7 +163,7 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
         && typeof adoptModeForTab === 'function') {
       adoptModeForTab(t, 'acceptEdits');
     }
-    clearBottomCard();                          // card disappears — composer returns
+    clearBottomCard(owner);                     // card disappears — composer returns
     if (d === 'deny' && msg) {
       // Keep the "User answered:" card: this is a decision the user made on a card,
       // and it reads as such. (A reload replays it from the transcript as a plain
@@ -221,12 +226,16 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
   // Number-key shortcuts map to the visible options in order; Esc cancels.
   function onKey(e) {
     if (resolved || document.activeElement === inp) return;
+    // A background tab's card (now that per-tab cards can coexist instead of
+    // evicting each other) isn't in the DOM — bail so its number/Esc shortcuts
+    // can't fire on whatever card the ACTIVE tab is actually showing.
+    if (!card.isConnected) { document.removeEventListener('keydown', onKey, true); return; }
     if (e.key === 'Escape') { e.preventDefault(); decide('deny', ''); return; }
     const n = parseInt(e.key, 10);
     if (n >= 1 && n <= opts.length) { e.preventDefault(); decide(opts[n - 1][0], ''); }
   }
   document.addEventListener('keydown', onKey, true);
-  registerCardCancel(() => decide('deny', ''));
+  registerCardCancel(() => decide('deny', ''), owner);
 
   // Java already answered "deny" to the CLI by the time this fires (its own
   // future.get(...) timed out) — this is presentation-only cleanup, so it must
@@ -246,7 +255,7 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
         pendingTool.appendChild(sub);
       }
     }
-    clearBottomCard();
+    clearBottomCard(owner);
     // addAnswered inserts a new sibling turn div; startFreshTurn must follow it
     // (curTurn = null) or the CLI's continuation streams into the turn ABOVE this
     // note instead of below it — the same pairing decide()'s message-deny branch
@@ -256,7 +265,7 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
     scrollBottom();
   });
 
-  showBottomCard(card);
+  showBottomCard(card, owner);
 };
 
 /* ---- AskUserQuestion card (single/multi question, options + Other) ---- */
@@ -271,6 +280,10 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   const t = tabById(tabId);
   if (t && t.cancelled) { if (window._answerQuestion) window._answerQuestion(reqId, '[]'); return; }  // stopped: no card
   if (t) loadRender(t);   // card belongs to this conversation
+  // Captured once, same reasoning as onApprovalRequest's owner: fixes which tab's
+  // card this closure's finish()/cancel() will show/clear, independent of rtab or
+  // activeTab() changing later (e.g. the user switches tabs before answering).
+  const owner = t || rtab || activeTab();
   const pane = streamPane() || (activeTab() ? activeTab().pane : null);
   let questions = [];
   try { questions = JSON.parse(questionsJson) || []; } catch (e) {}
@@ -313,7 +326,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
       question: q.question || '', answer: answeredText(i)
     }));
     if (window._answerQuestion) window._answerQuestion(reqId, JSON.stringify(answers));
-    clearBottomCard();
+    clearBottomCard(owner);
     const summary = answers.map(a => questions.length > 1 ? (a.header + ': ' + a.answer) : a.answer).join('\n');
     addAnswered(summary, pane); startFreshTurn(); scrollBottom();   // obeys Scroll Lock
   }
@@ -324,7 +337,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     document.removeEventListener('keydown', onKey, true);
     resolveDot(true);
     if (window._answerQuestion) window._answerQuestion(reqId, '[]');
-    clearBottomCard(); scrollBottom();   // obeys Scroll Lock
+    clearBottomCard(owner); scrollBottom();   // obeys Scroll Lock
   }
 
   function render() {
@@ -417,6 +430,10 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   }
   function onKey(e) {
     if (resolved) return;
+    // A background tab's card (now that per-tab cards can coexist instead of
+    // evicting each other) isn't in the DOM — bail so it can't intercept Esc
+    // meant for whatever card the ACTIVE tab is actually showing.
+    if (!card.isConnected) { document.removeEventListener('keydown', onKey, true); return; }
     // Capture-phase on document: runs before the Other field's own onkeydown, so
     // that handler's stopPropagation can't shield it — the tag check here is what
     // has to do it. Must accept TEXTAREA too now that Other is one (was INPUT-only
@@ -427,7 +444,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     if (e.key === 'Escape' && !inField) { e.preventDefault(); cancel(); }
   }
   document.addEventListener('keydown', onKey, true);
-  registerCardCancel(cancel);
+  registerCardCancel(cancel, owner);
 
   // Java already answered "[]" (dismissed) to the CLI by the time this fires — see
   // the matching comment on the approval card's registerCardTimeout for why this
@@ -437,7 +454,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     unregisterCardCancel();
     document.removeEventListener('keydown', onKey, true);
     resolveDot(true);
-    clearBottomCard();
+    clearBottomCard(owner);
     // Same pairing as finish(): addAnswered's new sibling turn div requires
     // startFreshTurn right after it (see the matching comment on the approval
     // card's timeout handler) so Claude's continuation lands below this note.
@@ -446,6 +463,6 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     scrollBottom();
   });
 
-  render(); showBottomCard(card);
+  render(); showBottomCard(card, owner);
 };
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -24,6 +24,9 @@
  *   undefined (a brand-new tab) means caught-up, same as true (see chat.js)
  * @property {number} [scrollTop] this tab's own #messages.scrollTop, parked on switch-away
  *   since #messages is one shared scroll container — undefined means "at the bottom"
+ * @property {HTMLElement|null} [pendingCard] this tab's own blocking approval/question/advisor
+ *   card, if one is currently awaiting an answer (see carddock.js) — kept per-tab so one tab's
+ *   card can never evict another's
  */
 /** @type {Tab[]} */
 let tabs = [], activeId = null, tabSeq = 0;
@@ -191,7 +194,8 @@ function closeTab(id, opts) {
   if (t.streaming && window._cancelRequest) window._cancelRequest(id);   // stop its stream
   if (window._disposeTab) window._disposeTab(id);                         // free its process
   if (rtab === t) rtab = null;
-  if (pendingCardOwner === t) { pendingCard = null; pendingCardOwner = null; }
+  // t.pendingCard (if any) goes with it — no separate global reference to clear now
+  // that the card lives on the Tab object itself.
   t.pane.remove();
   tabs.splice(idx, 1);
   if (opts.keepRoot) return;   // closeRoot is tearing the whole root down
@@ -340,8 +344,7 @@ function clearSession() {
   if (t.streaming) doCancel();
   hideWorking();
   curTurn = null; curBody = null; curText = ''; curThink = null; curThinkText = '';
-  if (pendingCardOwner === t) { pendingCard = null; pendingCardOwner = null; }
-  clearBottomCard();
+  clearBottomCard(t);   // drop this tab's own pending card, if any — /clear replaces its conversation
   // Drop the process so the next send starts a genuinely new conversation
   // (spawns without --resume) instead of continuing the one just cleared.
   if (window._disposeTab) window._disposeTab(t.id);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/working.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/working.js
@@ -251,7 +251,7 @@ setInterval(sweepStaleWorking, 2000);
 function ensureWorking() {
   // Operates on the render-target tab; don't show a gerund if that tab's own card
   // is pending (it replaces the working indicator).
-  if (rtab && rtab.streaming && !workingEl && !(pendingCard && pendingCardOwner === rtab)) showWorking();
+  if (rtab && rtab.streaming && !workingEl && !rtab.pendingCard) showWorking();
 }
 /* Live token count shown beside the "Thinking…" marker (real output tokens via the
    CLI partial-message stream), removed once thinking finalizes to "Thought for Ns". */


### PR DESCRIPTION
Keeps each conversation tab's own pending approval, question, or advisor card independent of every other tab's.

With several tabs running at once, a card opening in one tab could silently replace a card still waiting for an answer in another, leaving that tab stuck indefinitely. Makes multi-tab use reliable.