### PR TITLE
Match eclipse light theme colors

### DIFF
--- a/com.anthropic.claudecode.eclipse/META-INF/MANIFEST.MF
+++ b/com.anthropic.claudecode.eclipse/META-INF/MANIFEST.MF
@@ -32,6 +32,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.terminal.control;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.terminal.connector.process;bundle-version="[1.1.0,2.0.0)",
  org.eclipse.terminal.connector.local;bundle-version="[1.1.0,2.0.0)",
+ org.eclipse.e4.ui.workbench,
+ org.eclipse.e4.ui.model.workbench,
  com.google.gson
 Bundle-ClassPath: .
 Bundle-NativeCode: native/windows/x86_64/claude_eclipse_core.dll;\

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/stream.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/stream.js
@@ -102,9 +102,19 @@ function addCompacted(pane, trigger, freed, summaryText) {
 
 /* Light/dark theming (issue #78). Java pushes the ambient Eclipse theme via
    onTheme('light'|'dark') on load, on refocus, and on the workbench theme change;
-   the <html> class toggles the :root.light token overrides. Dark is the default. */
-window.onTheme = (mode) => {
+   the <html> class toggles the :root.light token overrides. Dark is the default.
+
+   tabBg/tabBgActive (optional): the REAL editor-area tab-folder colors, sampled
+   directly off Eclipse's own CTabFolder widget (ClaudeGuiView.findEditorAreaTabColors)
+   rather than guessed at in tokens.css — a hardcoded value can't be right for every
+   OS/GTK theme. Set as inline styles on :root, which win over both :root and
+   :root.light in the cascade without touching any selector; omitted (both undefined)
+   when Java couldn't sample them, leaving tokens.css's own values as the fallback. */
+window.onTheme = (mode, tabBg, tabBgActive) => {
   document.documentElement.classList.toggle('light', mode === 'light');
+  const root = document.documentElement.style;
+  if (tabBg) root.setProperty('--tab-bg', tabBg); else root.removeProperty('--tab-bg');
+  if (tabBgActive) root.setProperty('--tab-bg-active', tabBgActive); else root.removeProperty('--tab-bg-active');
 };
 
 /* A "User answered:" card left in the flow (at the decision point) when the user

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
@@ -16,7 +16,7 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 
 /* ── Top toolbar (VSCode editor-tab strip) ───────────────── */
 #toolbar { display: flex; align-items: stretch; height: 35px; flex-shrink: 0;
-  background: var(--bg); border-bottom: 1px solid var(--border-soft); }
+  background: var(--tab-bg); border-bottom: 1px solid var(--border-soft); }
 /* min-width:0 lets the strip shrink within the toolbar so its tabs scroll INTERNALLY
    (instead of pushing the toolbar tools off-screen). Thin bottom scrollbar, thumb
    visible only on hover — like VSCode. */
@@ -27,13 +27,17 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 #tabs::-webkit-scrollbar-track { background: transparent; }
 #tabs::-webkit-scrollbar-thumb { background: transparent; border-radius: 2px; }
 #tabs.sb-show::-webkit-scrollbar-thumb { background: var(--scrollbar-track); }
+/* --border (not --toolbar's --border-soft): now that inactive tabs share the
+   strip's own fill (--tab-bg) instead of standing out from it, they need a
+   visible edge to read as separate tabs rather than one undifferentiated bar. */
 .tab { display: flex; align-items: center; gap: 7px; padding: 0 10px; height: 100%; cursor: pointer;
-  background: var(--bg); border-right: 1px solid var(--border-soft); border-top: 2px solid transparent;
+  background: var(--tab-bg); border-right: 1px solid var(--border); border-top: 2px solid transparent;
   font-size: 12.5px; color: var(--fg-dim); max-width: 200px; flex-shrink: 0; }
-.tab.active { background: var(--bg-soft); border-top-color: var(--accent); color: var(--fg); }
-/* Hovering an unfocused tab previews it with the active tab's bg + text colors
-   (the accent top border stays exclusive to the truly active tab). */
-.tab:hover { background: var(--bg-soft); color: var(--fg); }
+.tab.active { background: var(--tab-bg-active); border-top-color: var(--accent); color: var(--fg); }
+/* Unchanged from the original --bg-soft behavior (--tab-hover-preview equals
+   --tab-bg-active in dark, same as before this token split) — hovering previews
+   the active look, and only the accent top border marks the truly active tab. */
+.tab:hover { background: var(--tab-hover-preview); color: var(--fg); }
 /* drag-to-reorder: dragged tab dims; a 2px accent line marks the drop position */
 .tab.dragging { opacity: .4; }
 .tab.drop-before { box-shadow: inset 2px 0 0 0 var(--accent); }
@@ -54,8 +58,12 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 .tbtn.active { background: var(--tbtn-active); color: var(--fg); }
 
 /* ── Conversation header ─────────────────────────────────── */
+/* Same chrome fill as #toolbar (--tab-bg): both rows sit above the content pane
+   (--bg), not as part of it, so the active tab above them is the only light thing
+   in that chrome strip. --border stays the stronger divider vs. --toolbar's
+   --border-soft since this is the direct boundary against the content pane. */
 #convo-header { display: flex; align-items: center; justify-content: space-between;
-  padding: 9px 14px; flex-shrink: 0; border-bottom: 1px solid var(--border); }
+  padding: 9px 14px; flex-shrink: 0; background: var(--tab-bg); border-bottom: 1px solid var(--border); }
 
 /* ---- CLI update banner ----
    Shown only when the installed Claude Code is behind the published release, so
@@ -79,7 +87,7 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
    pill's height is set here — the input is never forced to the pill's height. */
 #convo-header .title-wrap { display: flex; align-items: center; gap: 4px; min-width: 0; max-width: 340px;
   height: 32px; box-sizing: border-box; padding: 0 6px; border-radius: 8px; margin: -1px -6px; cursor: pointer; }
-#convo-header .title-wrap:hover { background: var(--bg-hover); }
+#convo-header .title-wrap:hover { background: var(--chrome-hover); }
 #convo-header .title { font-weight: 600; font-size: 13px; color: var(--fg); overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; }
 #convo-header .title-edit { color: var(--fg-faint); display: none; flex-shrink: 0; }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
@@ -40,6 +40,23 @@
   --send-off-fg: #8a7a72;     /* disabled send button fg */
   --on-accent: #fff;          /* text on accent/selection fills */
   --tbtn-active: #3a3550;     /* toolbar button toggled-on bg */
+  /* Tab strip: the ACTIVE tab must read as lighter/selected, matching the content
+     pane (--bg) it opens into; inactive tabs recede. --bg-soft can't be reused here
+     — it's shared with cards/composer, where "distinct surface" (not "lighter") is
+     the correct read, and in light mode --bg-soft is darker than --bg, which would
+     invert the tab relationship (issue: active tab looked grayer than inactive). */
+  --tab-bg: #1e1e1e;          /* inactive tab bg — matches --bg */
+  --tab-bg-active: #232323;   /* active tab bg — same as dark's old --bg-soft */
+  /* Unchanged from the original: dark's --bg-soft WAS the hover-preview value
+     (there was no distinct third value), so this equals --tab-bg-active exactly
+     — a hovered inactive tab previews the active look, same as before this token
+     split. Light needs a genuinely different (in-between) value — see that block. */
+  --tab-hover-preview: #232323;
+  /* Separate token for the title pill's hover fill (#convo-header .title-wrap):
+     needs a step clearly visible against --tab-bg specifically, not the tab strip's
+     inactive/active/hover relationship. In dark this equals --bg-hover's existing
+     value, since --tab-bg IS --bg here and nothing changed. */
+  --chrome-hover: #2f2f2f;
   --warn-border: #b58b2e;     /* usage-warning banner */
   --warn-bg: rgba(181,139,46,.12);
   --warn-fg: #d8b66a;
@@ -91,6 +108,20 @@
   --send-off-fg: #a89a92;
   --on-accent: #fff;
   --tbtn-active: #dfe3f0;
+  /* See the dark block's comment: active must be lighter than inactive. In light
+     mode that means active = pure white (matching --bg, the content pane), and
+     inactive recedes to a visible gray — the reverse of --bg-soft's #f3f3f3-on-
+     #ffffff relationship, which is correct for cards but was wrong for tabs. */
+  --tab-bg: #ececec;
+  --tab-bg-active: #ffffff;
+  /* A genuine in-between value (unlike dark, where hover always equalled active):
+     light's inactive (#ececec) and active (#ffffff) are close enough that jumping
+     straight to --tab-bg-active on hover reads as "did this just become active?" */
+  --tab-hover-preview: #f5f5f5;
+  /* --bg-hover (#e8e8e8) is only a 4-unit step from --tab-bg (#ececec) — too
+     close to read as a hover state on the title pill. A clearly darker value
+     against this specific base, not a reuse of a token calibrated for --bg. */
+  --chrome-hover: #dcdcdc;
   --warn-border: #c79a2e;
   --warn-bg: rgba(199,154,46,.14);
   --warn-fg: #8a6a12;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
@@ -111,17 +111,26 @@
   /* See the dark block's comment: active must be lighter than inactive. In light
      mode that means active = pure white (matching --bg, the content pane), and
      inactive recedes to a visible gray — the reverse of --bg-soft's #f3f3f3-on-
-     #ffffff relationship, which is correct for cards but was wrong for tabs. */
-  --tab-bg: #ececec;
+     #ffffff relationship, which is correct for cards but was wrong for tabs.
+     #f8f8f8 is not a guess: it's the real color a live GTK CTabFolder's
+     getBackground() reported (ClaudeGuiView.findEditorAreaTabColors samples it
+     dynamically at runtime and overrides this via inline style — this is only
+     the fallback for when that lookup fails, e.g. zero editors open at startup). */
+  --tab-bg: #f8f8f8;
   --tab-bg-active: #ffffff;
-  /* A genuine in-between value (unlike dark, where hover always equalled active):
-     light's inactive (#ececec) and active (#ffffff) are close enough that jumping
-     straight to --tab-bg-active on hover reads as "did this just become active?" */
-  --tab-hover-preview: #f5f5f5;
-  /* --bg-hover (#e8e8e8) is only a 4-unit step from --tab-bg (#ececec) — too
-     close to read as a hover state on the title pill. A clearly darker value
-     against this specific base, not a reuse of a token calibrated for --bg. */
-  --chrome-hover: #dcdcdc;
+  /* Static in both themes — NOT sampled at runtime like --tab-bg/--tab-bg-active
+     above. A genuine in-between value (unlike dark, where hover always equalled
+     active): light's inactive/active gap is small enough that jumping straight
+     to --tab-bg-active on hover reads as "did this just become active?" On a
+     theme whose sampled pair differs a lot from #f8f8f8/#ffffff this fixed value
+     could land outside that pair's range and invert hover again — a known gap,
+     not yet worth deriving from the sample without another data point. */
+  --tab-hover-preview: #fbfbfb;
+  /* Also static/not sampled. --bg-hover (#e8e8e8) reads as too subtle a step
+     against --tab-bg's lighter #f8f8f8 base to register as a hover state on the
+     title pill. A clearly visible value against this specific base, not a reuse
+     of a token calibrated for --bg. */
+  --chrome-hover: #ebebeb;
   --warn-border: #c79a2e;
   --warn-bg: rgba(199,154,46,.14);
   --warn-fg: #8a6a12;

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -634,7 +634,8 @@ public class ClaudeGuiView extends ViewPart {
         String[] use = tabColors != null ? tabColors : lastEditorAreaTabColors;
         if (Activator.getDefault().getPreferenceStore().getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_DEBUG_MODE)) {
             Activator.log("editor-area tab colors: "
-                    + (use == null ? "unavailable" : use[0] + " / " + use[1]) + " (mode=" + mode + ")");
+                    + (use == null ? "unavailable" : use[0] + " / " + use[1]) + " (mode=" + mode + ")"
+                    + " [" + lastTabColorsDiagnostic + "]");
         }
         String call = "window.onTheme && window.onTheme('" + mode + "'"
                 + (use != null ? ",'" + use[0] + "','" + use[1] + "'" : "")
@@ -661,6 +662,11 @@ public class ClaudeGuiView extends ViewPart {
      * {@code null} if the editor area isn't in the model yet, isn't rendered as a
      * CTabFolder (e.g. zero editors open), or the colors aren't readable.
      */
+    /** Set by {@link #findEditorAreaTabColors()} on every call — which step it got to,
+     *  for the debug-mode log line in {@link #pushTheme()} (this method itself only
+     *  returns null/non-null, so this is the only way to see WHERE it failed). */
+    private String lastTabColorsDiagnostic = "not yet run";
+
     private String[] findEditorAreaTabColors() {
         try {
             org.eclipse.ui.IWorkbench wb = org.eclipse.ui.PlatformUI.getWorkbench();
@@ -668,22 +674,60 @@ public class ClaudeGuiView extends ViewPart {
                     wb.getService(org.eclipse.e4.ui.workbench.modeling.EModelService.class);
             org.eclipse.e4.ui.model.application.MApplication application =
                     wb.getService(org.eclipse.e4.ui.model.application.MApplication.class);
-            if (modelService == null || application == null) return null;
+            if (modelService == null || application == null) {
+                lastTabColorsDiagnostic = "modelService=" + modelService + " application=" + application;
+                return null;
+            }
 
             org.eclipse.e4.ui.model.application.ui.MUIElement element =
                     modelService.find(org.eclipse.ui.IPageLayout.ID_EDITOR_AREA, application);
+            String elementClassBeforeDeref = element == null ? "null" : element.getClass().getName();
             if (element instanceof org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder ph) {
                 element = ph.getRef();
             }
-            if (!(element instanceof org.eclipse.e4.ui.model.application.ui.basic.MPartStack stack)) return null;
-            if (!(stack.getWidget() instanceof org.eclipse.swt.custom.CTabFolder tabFolder)) return null;
-            if (tabFolder.isDisposed()) return null;
+            // ID_EDITOR_AREA resolves to an MArea (the editor area's own container),
+            // NOT the MPartStack directly — confirmed by logging the actual class here
+            // against a live GTK session. The real per-editor tab folder (the one
+            // showing open file tabs) is a descendant of it, tagged by E4's renderer
+            // with a CSS class name containing "EditorStack" — findElements walks
+            // down to find it rather than assuming a fixed nesting depth, since that
+            // can vary with split editors / multiple editor areas.
+            if (!(element instanceof org.eclipse.e4.ui.model.application.ui.advanced.MArea area)) {
+                lastTabColorsDiagnostic = "find(" + org.eclipse.ui.IPageLayout.ID_EDITOR_AREA + ") -> "
+                        + elementClassBeforeDeref + ", after MPlaceholder deref -> "
+                        + (element == null ? "null" : element.getClass().getName()) + " (want MArea)";
+                return null;
+            }
+            // A split editor area has more than one MPartStack descendant. Prefer the
+            // one E4 itself tags as the primary data stack (confirmed present as a
+            // literal tag, not the element ID, via a live GTK log dump); fall back to
+            // the first live one so a split editor still works even if some future
+            // Eclipse version stops tagging it this way.
+            org.eclipse.swt.custom.CTabFolder tabFolder = null;
+            org.eclipse.swt.custom.CTabFolder firstLive = null;
+            for (org.eclipse.e4.ui.model.application.ui.basic.MPartStack stack
+                    : modelService.findElements(area, null, org.eclipse.e4.ui.model.application.ui.basic.MPartStack.class)) {
+                if (!(stack.getWidget() instanceof org.eclipse.swt.custom.CTabFolder ctf) || ctf.isDisposed()) continue;
+                if (firstLive == null) firstLive = ctf;
+                if (stack.getTags().contains("org.eclipse.e4.primaryDataStack")) { tabFolder = ctf; break; }
+            }
+            if (tabFolder == null) tabFolder = firstLive;
+            if (tabFolder == null) {
+                lastTabColorsDiagnostic = "MArea found, but no descendant MPartStack has a live CTabFolder widget"
+                        + " (zero editors open, or the editor area isn't rendered yet)";
+                return null;
+            }
 
             org.eclipse.swt.graphics.Color inactive = tabFolder.getBackground();
             org.eclipse.swt.graphics.Color active = tabFolder.getSelectionBackground();
-            if (inactive == null || inactive.isDisposed() || active == null || active.isDisposed()) return null;
+            if (inactive == null || inactive.isDisposed() || active == null || active.isDisposed()) {
+                lastTabColorsDiagnostic = "inactive=" + inactive + " active=" + active + " (disposed or null)";
+                return null;
+            }
+            lastTabColorsDiagnostic = "ok";
             return new String[]{ ColorUtils.toHex(inactive.getRGB()), ColorUtils.toHex(active.getRGB()) };
-        } catch (Exception ignore) {
+        } catch (Exception e) {
+            lastTabColorsDiagnostic = "threw " + e;
             return null;
         }
     }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -611,11 +611,81 @@ public class ClaudeGuiView extends ViewPart {
      * :root.light CSS token overrides. The theme is derived from the perceived luminance
      * of the widget background — the actually-painted color, so it's correct for custom
      * themes too (issue #78). Dark is the default and stays visually unchanged.
+     *
+     * <p>Also pushes the ACTUAL native editor-area tab-folder colors when reachable (see
+     * {@link #findEditorAreaTabColors()}), so the webview's own tab strip (#toolbar /
+     * #convo-header) matches Eclipse's real chrome instead of a hardcoded guess at it —
+     * a single hardcoded value can't be right for every OS/GTK theme (the GTK chrome
+     * gray looks nothing like Windows' or macOS'). Passed as optional 2nd/3rd args;
+     * the webview's tokens.css values are the fallback when null (the editor area
+     * isn't reachable or rendered yet — see that method's comment). Deliberately the
+     * EDITOR area specifically, not wherever this view itself happens to be docked:
+     * the view-stack and editor-stack active-tab styling differ in Eclipse, and the
+     * editor style is the one this webview's own tab strip is designed to match.
      */
     private void pushTheme() {
         if (browser == null || browser.isDisposed() || !pageLoaded) return;
         String mode = isDarkTheme() ? "dark" : "light";
-        browser.execute("window.onTheme && window.onTheme('" + mode + "')");
+        String[] tabColors = findEditorAreaTabColors();
+        if (tabColors != null) lastEditorAreaTabColors = tabColors;
+        // Falls back to the last successfully sampled colors (not the CSS default)
+        // when the editor area is momentarily unreachable (e.g. zero editors open),
+        // so the tab strip doesn't visibly shift color depending on editor state.
+        String[] use = tabColors != null ? tabColors : lastEditorAreaTabColors;
+        if (Activator.getDefault().getPreferenceStore().getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_DEBUG_MODE)) {
+            Activator.log("editor-area tab colors: "
+                    + (use == null ? "unavailable" : use[0] + " / " + use[1]) + " (mode=" + mode + ")");
+        }
+        String call = "window.onTheme && window.onTheme('" + mode + "'"
+                + (use != null ? ",'" + use[0] + "','" + use[1] + "'" : "")
+                + ")";
+        browser.execute(call);
+    }
+
+    /** Last successfully sampled {@code {inactiveHex, activeHex}} from {@link
+     *  #findEditorAreaTabColors()}, kept so a momentarily-unreachable editor area
+     *  (e.g. zero editors open) doesn't flicker the tab strip back to the CSS default. */
+    private String[] lastEditorAreaTabColors;
+
+    /**
+     * Finds the EDITOR area's {@link org.eclipse.swt.custom.CTabFolder} — the real
+     * "History | Claude Code | ..." tab strip when editors are docked there — via
+     * the E4 model, and samples its actual painted colors: inactive-tab background
+     * ({@code getBackground()}) and active-tab background ({@code
+     * getSelectionBackground()}). Both are read directly off the widget rather than
+     * through the CSS engine: E4 themes a CTabFolder by calling these same setters,
+     * so the getters already return the themed value, and going through {@code
+     * IThemeEngine}'s CSS layer would mean casting its implementation to an internal
+     * type and manually disposing the Color objects it allocates — extra risk for a
+     * value the widget already holds. Returns {@code {inactiveHex, activeHex}}, or
+     * {@code null} if the editor area isn't in the model yet, isn't rendered as a
+     * CTabFolder (e.g. zero editors open), or the colors aren't readable.
+     */
+    private String[] findEditorAreaTabColors() {
+        try {
+            org.eclipse.ui.IWorkbench wb = org.eclipse.ui.PlatformUI.getWorkbench();
+            org.eclipse.e4.ui.workbench.modeling.EModelService modelService =
+                    wb.getService(org.eclipse.e4.ui.workbench.modeling.EModelService.class);
+            org.eclipse.e4.ui.model.application.MApplication application =
+                    wb.getService(org.eclipse.e4.ui.model.application.MApplication.class);
+            if (modelService == null || application == null) return null;
+
+            org.eclipse.e4.ui.model.application.ui.MUIElement element =
+                    modelService.find(org.eclipse.ui.IPageLayout.ID_EDITOR_AREA, application);
+            if (element instanceof org.eclipse.e4.ui.model.application.ui.advanced.MPlaceholder ph) {
+                element = ph.getRef();
+            }
+            if (!(element instanceof org.eclipse.e4.ui.model.application.ui.basic.MPartStack stack)) return null;
+            if (!(stack.getWidget() instanceof org.eclipse.swt.custom.CTabFolder tabFolder)) return null;
+            if (tabFolder.isDisposed()) return null;
+
+            org.eclipse.swt.graphics.Color inactive = tabFolder.getBackground();
+            org.eclipse.swt.graphics.Color active = tabFolder.getSelectionBackground();
+            if (inactive == null || inactive.isDisposed() || active == null || active.isDisposed()) return null;
+            return new String[]{ ColorUtils.toHex(inactive.getRGB()), ColorUtils.toHex(active.getRGB()) };
+        } catch (Exception ignore) {
+            return null;
+        }
     }
 
     /**

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ColorUtils.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ColorUtils.java
@@ -20,4 +20,9 @@ public final class ColorUtils {
     public static double luminance(RGB rgb) {
         return luminance(rgb.red, rgb.green, rgb.blue);
     }
+
+    /** Formats an SWT {@link RGB} as a CSS hex color ({@code "#rrggbb"}). */
+    public static String toHex(RGB rgb) {
+        return String.format("#%02x%02x%02x", rgb.red, rgb.green, rgb.blue);
+    }
 }


### PR DESCRIPTION
## Summary
- On GTK/light themes, the tab strip's active/inactive colors were inverted: the active tab and `#toolbar`/`#convo-header` reused `--bg-soft`, which in light mode (`#f3f3f3`) is *darker* than the page background `--bg` (`#ffffff`) — the opposite of dark mode, where `--bg-soft` is lighter than `--bg`. The active tab ended up reading as grayer than the inactive ones.
- Adds dedicated `--tab-bg` / `--tab-bg-active` / `--tab-hover-preview` / `--chrome-hover` tokens instead of reusing `--bg-soft` (which is correctly shared by cards/composer, where the opposite relationship is the right one).
- Goes further than a static fix: rather than guessing at a hardcoded chrome color that "might not work for everyone" on GTK, the tab strip now samples Eclipse's own real, live editor-area tab-folder colors at runtime (`CTabFolder.getBackground()` / `getSelectionBackground()`) and pushes them into the page as CSS custom properties — so it automatically matches whatever theme (including dark GTK themes, high-contrast, or custom themes) the user actually has, not just the one this was authored against. The CSS token values remain only as a fallback for when live sampling isn't available yet (e.g. no editors open at startup).

## Changes
- `tokens.css`: new `--tab-bg`/`--tab-bg-active`/`--tab-hover-preview`/`--chrome-hover` tokens (dark values reproduce the original look exactly; light values fixed, using a real measured GTK value as the fallback).
- `layout.css`: tab strip and header now use the new tokens; `.tab`'s border strengthened from `--border-soft` to `--border` for visible contrast now that its background matches the toolbar's own.
- `stream.js`: `window.onTheme` accepts optional live-sampled tab colors and applies them as inline CSS custom properties, overriding the static tokens.
- `ClaudeGuiView.java`: new `findEditorAreaTabColors()` walks the E4 model (`IPageLayout.ID_EDITOR_AREA` → `MArea` → descendant `MPartStack`, preferring the one tagged `org.eclipse.e4.primaryDataStack`) to find the real editor-area `CTabFolder` and read its live colors.
- `MANIFEST.MF`: adds the `org.eclipse.e4.ui.workbench` / `org.eclipse.e4.ui.model.workbench` bundle dependencies this needs.
- `ColorUtils.java`: adds a small `toHex(RGB)` helper.

## Test plan
- [x] Verified live on GTK: debug log shows `editor-area tab colors: #f8f8f8 / #ffffff (mode=light) [ok]`, sampled dynamically (not the CSS fallback) — confirmed the active tab now reads correctly as lighter than inactive tabs, matching the editor area's own native chrome.
- [x] Sanity check on a dark GTK theme / other platforms that sampling still resolves correctly and falls back gracefully when no editors are open.