### PR TITLE
Add an optional timestamp above your own messages

### DIFF
--- a/claude-eclipse-core/src/session.rs
+++ b/claude-eclipse-core/src/session.rs
@@ -386,6 +386,14 @@ pub fn load_session_history(workspace_root: &str, session_id: &str) -> String {
                                 item["id"] = serde_json::Value::from(u);
                             }
                         }
+                        // ISO 8601, same field list_sessions already reads for its own
+                        // sort key — forwarded so the GUI can show it above the bubble
+                        // (opt-in preference), not currently used for anything else here.
+                        if let Some(ts) = event["timestamp"].as_str() {
+                            if !ts.is_empty() {
+                                item["ts"] = serde_json::Value::from(ts);
+                            }
+                        }
                         items.push(item);
                     }
                 } else if let Some(blocks) = content.as_array() {
@@ -429,6 +437,11 @@ pub fn load_session_history(workspace_root: &str, session_id: &str) -> String {
                         if let Some(u) = event["uuid"].as_str() {
                             if !u.is_empty() {
                                 item["id"] = serde_json::Value::from(u);
+                            }
+                        }
+                        if let Some(ts) = event["timestamp"].as_str() {
+                            if !ts.is_empty() {
+                                item["ts"] = serde_json::Value::from(ts);
                             }
                         }
                         items.push(item);
@@ -1146,7 +1159,7 @@ mod tests {
         // toolu_01 (askUserQuestion) has a non-error tool_result → status "done";
         // toolu_02 (Edit) has no tool_result in the fixture → status "interrupted".
         let want1: serde_json::Value = serde_json::from_str(r#"[
-            {"t":"user","content":"<ide_selection a=\"b\">sel junk</ide_selection>please fix the bug"},
+            {"t":"user","content":"<ide_selection a=\"b\">sel junk</ide_selection>please fix the bug","ts":"2026-07-01T10:00:00.000Z"},
             {"t":"thinking","model":"claude-fable-5","text":"hmm secret"},
             {"t":"text","text":"Here is my answer","model":"claude-fable-5"},
             {"t":"tool","name":"mcp__eclipse__askUserQuestion","input":{"q":"Which color?"},"model":"claude-fable-5","status":"done"},
@@ -1157,7 +1170,7 @@ mod tests {
 
         let got2: serde_json::Value = serde_json::from_str(&loaded2).unwrap();
         let want2: serde_json::Value = serde_json::from_str(r#"[
-            {"t":"user","content":"<command-name>/clear</command-name><command-message>clear</command-message><command-args>now</command-args>"}
+            {"t":"user","content":"<command-name>/clear</command-name><command-message>clear</command-message><command-args>now</command-args>","ts":"2026-07-03T08:00:00.000Z"}
         ]"#).unwrap();
         assert_eq!(got2, want2, "sess2: raw user kept, non-ask tool_result ignored");
 
@@ -1198,12 +1211,12 @@ mod tests {
 
         let got: serde_json::Value = serde_json::from_str(&loaded).unwrap();
         let want: serde_json::Value = serde_json::from_str(r#"[
-            {"t":"user","content":"tell me things"},
+            {"t":"user","content":"tell me things","ts":"2026-07-27T02:00:00.000Z"},
             {"t":"text","text":"things","model":"claude-haiku-4-5-20251001"},
             {"t":"compact","trigger":"manual","preTokens":23670,"postTokens":1682},
             {"t":"compact_summary","text":"This session is being continued from a previous conversation. Summary: things were told."},
-            {"t":"user","content":"<local-command-caveat>Caveat: ...</local-command-caveat>"},
-            {"t":"user","content":"<command-name>/compact</command-name>"}
+            {"t":"user","content":"<local-command-caveat>Caveat: ...</local-command-caveat>","ts":"2026-07-27T02:37:08.120Z"},
+            {"t":"user","content":"<command-name>/compact</command-name>","ts":"2026-07-27T02:37:08.130Z"}
         ]"#).unwrap();
         assert_eq!(got, want, "compacted session render items");
     }
@@ -1238,7 +1251,7 @@ mod tests {
         let got: serde_json::Value = serde_json::from_str(&loaded).unwrap();
         let want: serde_json::Value = serde_json::from_str(r#"[
             {"t":"user","content":"<ide_context openFile=\"C:\\a\\B.java\" />\n\nwhat is this",
-             "images":[{"media_type":"image/jpeg","data":"QUJD"}]},
+             "images":[{"media_type":"image/jpeg","data":"QUJD"}],"ts":"2026-07-30T01:00:00.000Z"},
             {"t":"tool","name":"Read","input":{"file_path":"a.txt"},"status":"done","model":"claude-opus-4-8"},
             {"t":"text","text":"a screenshot","model":"claude-opus-4-8"}
         ]"#).unwrap();
@@ -1286,7 +1299,7 @@ mod tests {
 
         let got: serde_json::Value = serde_json::from_str(&loaded).unwrap();
         let want: serde_json::Value = serde_json::from_str(r#"[
-            {"t":"user","content":"go"},
+            {"t":"user","content":"go","ts":"2026-08-26T01:00:00.000Z"},
             {"t":"text","text":"working on it","model":"claude-opus-4-8"},
             {"t":"error","text":"You've hit your session limit · resets 2:10am (Asia/Irkutsk)"},
             {"t":"error","text":"API Error: 529 Overloaded. This is a server-side issue, usually temporary — try again in a moment. If it persists, check https://status.claude.com."}

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
@@ -84,7 +84,7 @@ function openAdvisorCard(echoText) {
     // The "/advisor" echo lands HERE, not when the card opened: the command only
     // becomes part of the conversation once a choice is made. Cancel/Esc runs
     // cancel() instead, which adds nothing at all.
-    if (echoText) addUserMessage(echoText);
+    if (echoText) addUserMessage(echoText, null, null, null, nowIso());
     // Target the active tab: addSystem() would follow the render tab instead.
     addSystemTo(activeTab(), value ? 'Advisor set to ' + label + '.' : 'Advisor disabled.');
     scrollBottom();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -93,17 +93,45 @@ function scrollBottom(force) {
   }
   autoScroll();
 }
+/** The timestamp a LIVE send happens at — pass this explicitly at every send call
+ *  site (never inferred inside addUserMessage itself, see its own doc comment). */
+function nowIso() { return new Date().toISOString(); }
+/** Formats an ISO timestamp as a short local time for TODAY, or date+time otherwise —
+ *  same today/older split as history.js's own relTime(), so the two read consistently. */
+function absTime(iso) {
+  const t = Date.parse(iso); if (isNaN(t)) return '';
+  const d = new Date(t);
+  const timePart = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+  const today = new Date();
+  const isToday = d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth()
+      && d.getDate() === today.getDate();
+  return isToday ? timePart : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ', ' + timePart;
+}
 /**
  * @param {string} text @param {string|null} [ctx] context-chip label (file:lines)
  * @param {{url: string, name: string, w: number, h: number}[]} [images] pasted-image chips
  * @param {string} [id] transcript uuid — enables this bubble's hover actions. A
  *   live send has none yet (the CLI writes the line after us); backfillMessageIds
  *   fills it in once the turn ends.
+ * @param {string} [ts] ISO timestamp for the opt-in line above the bubble
+ *   (PREF_HISTORY_SHOW_TIMESTAMPS / window.__historyShowTimestamps). NOT defaulted to
+ *   "now" here on purpose: a caller reconstructing history that has no recorded
+ *   timestamp (an older session predating this field, or a line the CLI itself never
+ *   stamped) must pass nothing and get no line, rather than this function silently
+ *   rendering today's time on a message from last week. Every LIVE send site passes
+ *   `new Date().toISOString()` itself instead.
  */
-function addUserMessage(text, ctx, images, id) {
+function addUserMessage(text, ctx, images, id, ts) {
   const pane = activeTab() ? activeTab().pane : messagesEl;
   clearWelcome(pane);
   const turn = document.createElement('div'); turn.className = 'turn';
+  if (window.__historyShowTimestamps && ts) {
+    const label = absTime(ts);
+    if (label) {
+      const tsEl = document.createElement('div'); tsEl.className = 'msg-ts'; tsEl.textContent = label;
+      turn.appendChild(tsEl);
+    }
+  }
   const box = document.createElement('div'); box.className = 'user-msg';
   if (id) box.dataset.mid = id;
   box.appendChild(makeMsgActions());
@@ -427,7 +455,7 @@ function doSend() {
   const queueing = !!t.streaming;
   const withCtx = !!(ctxEnabled && ctxData && ctxData.fileName);
   const imagesJson = (typeof pendingImagesJson === 'function') ? pendingImagesJson(t) : '';
-  addUserMessage(text, withCtx ? ctxChipLabel() : null, imgs);
+  addUserMessage(text, withCtx ? ctxChipLabel() : null, imgs, null, nowIso());
   if (!t.titled && text) setTabTitle(t, text);   // title from text; an image-only first turn stays untitled
   input.value = ''; input.style.height = 'auto'; t.draft = ''; closeSlash();
   if (typeof clearPendingImages === 'function') clearPendingImages(t);   // consumed → clear the strip

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -286,7 +286,7 @@ function loadHistory(id, title) {
       if (/^\[Image:[^\]]*\]$/.test(marker)) return;
       // Messages sent with pasted images carry them as {media_type,data} blocks —
       // rebuild the same chips the live bubble showed.
-      if (!invisible) addUserMessage(p.text, p.chip, imgs, it.id);
+      if (!invisible) addUserMessage(p.text, p.chip, imgs, it.id, it.ts);
       if (isCompactCmd) flushCompact();
     } else if (ty === 'answered') {
       flushCompact();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
@@ -86,7 +86,7 @@ function handleSlashCommand(text) {
   // Clears the conversation IN THE CURRENT TAB, then echoes the command so it's
   // the only message left in the fresh session (joebiden7). Deliberately not
   // newSession() — VSCode stays on the tab /clear was invoked from.
-  if (cmd === '/clear') { clearSession(); addUserMessage(text); return true; }
+  if (cmd === '/clear') { clearSession(); addUserMessage(text, null, null, null, nowIso()); return true; }
   if (cmd === '/compact') { sendCompact(); return true; }          // echoes itself
   // Echo is deferred to the card's confirm() — cancel/Esc adds nothing.
   if (cmd === '/advisor') { openAdvisorCard(text); return true; }
@@ -94,7 +94,7 @@ function handleSlashCommand(text) {
   if (cmd === '/rewind') { openRewindDialog(); return true; }      // deliberately unchanged
   if (cmd === '/help') {
     const ht = activeTab();
-    addUserMessage(text);
+    addUserMessage(text, null, null, null, nowIso());
     addSystemTo(ht, 'Commands: /advisor — set up an advisor model · /clear — new conversation · /compact — compact the conversation into a summary · /model — switch model · /rewind — restore code and fork from an earlier message · /help — this list. Type / to see them.');
     return true;
   }
@@ -113,7 +113,7 @@ function handleModelCommand(text) {
   // one you typed in — a reply to a command you just ran belongs in the tab you
   // ran it in, so target it explicitly.
   const t = activeTab();
-  addUserMessage(text);
+  addUserMessage(text, null, null, null, nowIso());
   const arg = text.slice('/model'.length).trim();
   if (!arg) {
     addSystemTo(t, 'Current model: ' + modelLabelFor(curModel) + ' (effort: ' + effort + ')\n'
@@ -160,7 +160,7 @@ function sendSlashToCli(text) {
   t.cancelled = false;
   loadRender(t);
   const queueing = !!t.streaming;
-  addUserMessage(text);
+  addUserMessage(text, null, null, null, nowIso());
   closeSlash();
   if (!queueing) { setStreaming(true); showWorking(); }
   else if (!workingEl) showWorking();
@@ -177,7 +177,7 @@ function sendCompact() {
   t.cancelled = false;
   loadRender(t);
   const queueing = !!t.streaming;
-  addUserMessage('/compact');
+  addUserMessage('/compact', null, null, null, nowIso());
   input.value = ''; input.style.height = 'auto'; t.draft = ''; closeSlash();
   t.compacting = true;
   if (!queueing) { setStreaming(true); showWorking(); }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
@@ -50,6 +50,11 @@
   background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='8'%3E%3Cpath d='M0 4 Q4 0 8 4 T16 4' fill='none' stroke='%236e6e6e' stroke-width='1'/%3E%3C/svg%3E") repeat-x center; }
 .switch-divider .sw-text { white-space: nowrap; }
 
+/* Opt-in timestamp line above a user bubble (PREF_HISTORY_SHOW_TIMESTAMPS). Its own
+   line in the turn, not part of .user-msg, so it never shifts the bubble's own padding
+   or the hover-actions badges pinned to .user-msg's corner. */
+.msg-ts { color: var(--fg-faint); font-size: 10.5px; margin: 0 2px 4px; }
+
 /* user bubble */
 .user-msg { position: relative; border: 1px solid var(--border); background: var(--bg-soft);
   border-radius: 8px; padding: 10px 12px; }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -70,6 +70,13 @@ public final class Constants {
     /** Claude's idle re-run timer for the statusLine command, in seconds. */
     public static final String PREF_STATUSLINE_REFRESH_SECONDS = "statuslineRefreshSeconds";
 
+    /** Show a small timestamp line above each of your own messages, in the Claude Code
+     *  view — live sends and loaded history both, in local time (the record itself is
+     *  UTC; see {@code load_session_history} in {@code session.rs}). Off by default:
+     *  the same information is already one hover away in the History panel's own
+     *  per-session time, so this trades a bit of vertical space for always-visible detail. */
+    public static final String PREF_HISTORY_SHOW_TIMESTAMPS = "historyShowTimestamps";
+
     // ── Spinner verbs ───────────────────────────────────────────────────────
     // Which optional slices of the working-indicator gerund list are in rotation.
     // Each names a membership set over the single master list in working.js

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -150,6 +150,8 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     private ClaudeStatusBar statusBar;
     // Live-applies PREF_STATUSLINE_* changes (enable/toggles/refresh) without a restart.
     private org.eclipse.jface.util.IPropertyChangeListener statusPrefListener;
+    // Live-applies PREF_HISTORY_SHOW_TIMESTAMPS changes without a restart or page reload.
+    private org.eclipse.jface.util.IPropertyChangeListener historyShowTimestampsPrefListener;
     // Re-pushes light/dark to the webview when the Eclipse workbench theme changes.
     private org.eclipse.jface.util.IPropertyChangeListener themeChangeListener;
     // Re-pushes the right-click menu's key hints when the user's bindings change.
@@ -220,6 +222,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // this view sees them without having to send a turn first (issue #99).
         fetchUsageAsync();
         registerStatusPrefListener();
+        registerHistoryShowTimestampsPrefListener();
         registerThemeListener();
         registerBindingListener();
         registerEditHandlers();
@@ -954,6 +957,19 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         Activator.getDefault().getPreferenceStore().addPropertyChangeListener(statusPrefListener);
     }
 
+    /** Live-applies a Preferences change to "show message timestamps" without needing a
+     *  page reload or the view to regain focus — mirrors {@link #registerStatusPrefListener()}.
+     *  Without this, saving the preference from a Preferences dialog that never took focus
+     *  away from (and back to) this view left the old value pushed at page-load in place
+     *  until the next {@link #setFocus()}. */
+    private void registerHistoryShowTimestampsPrefListener() {
+        historyShowTimestampsPrefListener = event -> {
+            if (!com.anthropic.claudecode.eclipse.Constants.PREF_HISTORY_SHOW_TIMESTAMPS.equals(event.getProperty())) return;
+            Display.getDefault().asyncExec(this::pushHistoryShowTimestamps);
+        };
+        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(historyShowTimestampsPrefListener);
+    }
+
     /**
      * Live theme refresh driven by the JFace {@link org.eclipse.jface.resource.ColorRegistry},
      * the SAME signal that recolors the shared status bar the instant the Eclipse theme changes
@@ -1297,9 +1313,10 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
 
     /**
      * Tells the page whether to show a timestamp above each of your own messages.
-     * Re-pushed on activation (see {@link #setFocus()}), same as {@link #pushDebugMode()},
-     * so ticking the box in Preferences takes effect on the next focus rather than only
-     * the next page load — cheap since it is read once per render, not live-watched.
+     * Re-pushed on activation and on every live Preferences change (see
+     * {@link #registerHistoryShowTimestampsPrefListener()}) — a Preferences dialog OK
+     * doesn't reload the page or necessarily refocus this view, so without the live
+     * push a mid-session toggle would sit unapplied until the next focus.
      */
     private void pushHistoryShowTimestamps() {
         if (browser == null || browser.isDisposed() || !pageLoaded) return;
@@ -2399,6 +2416,11 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(statusPrefListener); }
             catch (Throwable ignored) {}
             statusPrefListener = null;
+        }
+        if (historyShowTimestampsPrefListener != null) {
+            try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(historyShowTimestampsPrefListener); }
+            catch (Throwable ignored) {}
+            historyShowTimestampsPrefListener = null;
         }
         if (themeChangeListener != null) {
             try {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -571,6 +571,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             pushCliModels();         // ditto for the installed binary's model support
             pushEditKeyHints();      // label the right-click menu with the user's real keys
             pushDebugMode();         // let the page report its keys while Debug mode is on
+            pushHistoryShowTimestamps(); // whether to show a timestamp above your own messages
             pushSpinnerVerbs();      // which gerund categories the working indicator cycles
             // An "Open Claude Code Here" that arrived while the view was still loading.
             String queuedRoot = pendingRootPath;
@@ -1295,6 +1296,19 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     }
 
     /**
+     * Tells the page whether to show a timestamp above each of your own messages.
+     * Re-pushed on activation (see {@link #setFocus()}), same as {@link #pushDebugMode()},
+     * so ticking the box in Preferences takes effect on the next focus rather than only
+     * the next page load — cheap since it is read once per render, not live-watched.
+     */
+    private void pushHistoryShowTimestamps() {
+        if (browser == null || browser.isDisposed() || !pageLoaded) return;
+        boolean show = Activator.getDefault().getPreferenceStore()
+                .getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_HISTORY_SHOW_TIMESTAMPS);
+        browser.execute("window.__historyShowTimestamps = " + show + ";");
+    }
+
+    /**
      * Tells the page which optional slices of the working-indicator gerund list are in
      * rotation (Preferences &gt; Claude Code &gt; Miscellaneous Configuration). Sent as one
      * JSON object rather than positional booleans so adding a category later doesn't
@@ -1918,6 +1932,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // change shows up in the right-click menu's hints on the next activation.
         pushEditKeyHints();
         pushDebugMode();
+        pushHistoryShowTimestamps();
         pushSpinnerVerbs();
     }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -45,6 +45,8 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY, true);
         store.setDefault(Constants.PREF_STATUSLINE_REFRESH_SECONDS, 60);
 
+        store.setDefault(Constants.PREF_HISTORY_SHOW_TIMESTAMPS, false);
+
         // Claude Code view spinner verbs — the three that were already in rotation
         // stay on; dank and the vibecoder claim are opt-in.
         store.setDefault(Constants.PREF_SPINNER_DEPRECATED, true);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -254,6 +254,11 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         miscLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 
         addField(new BooleanFieldEditor(
+                Constants.PREF_HISTORY_SHOW_TIMESTAMPS,
+                "Show a timestamp above your own messages, in the Claude Code view",
+                getFieldEditorParent()));
+
+        addField(new BooleanFieldEditor(
                 Constants.PREF_SPINNER_DEPRECATED,
                 "Use deprecated spinner verbs",
                 getFieldEditorParent()));


### PR DESCRIPTION
Adds an opt-in preference that shows a small local-time timestamp above each message you send, for both live conversations and history loaded from disk.

Useful for anyone who refers back to a long-running conversation and wants to know when a specific message was sent.