### PR TITLE
Show when usage limits reset, as separate preferences

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -67,6 +67,10 @@ public final class Constants {
     public static final String PREF_STATUSLINE_SHOW_COST = "statuslineShowCost";
     public static final String PREF_STATUSLINE_SHOW_SESSION_5H = "statuslineShowSession5h";
     public static final String PREF_STATUSLINE_SHOW_WEEKLY = "statuslineShowWeekly";
+    /** Show "(resets in ...)" next to the Session/Weekly meters, in both views —
+     *  the reset epoch lands in the same process-wide {@code ClaudeStatusStore}
+     *  regardless of which view's data channel supplied it. */
+    public static final String PREF_STATUSLINE_SHOW_RESETS = "statuslineShowResets";
     /** Claude's idle re-run timer for the statusLine command, in seconds. */
     public static final String PREF_STATUSLINE_REFRESH_SECONDS = "statuslineRefreshSeconds";
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -66,11 +66,13 @@ public final class Constants {
     public static final String PREF_STATUSLINE_SHOW_CONTEXT = "statuslineShowContext";
     public static final String PREF_STATUSLINE_SHOW_COST = "statuslineShowCost";
     public static final String PREF_STATUSLINE_SHOW_SESSION_5H = "statuslineShowSession5h";
+    /** Show "(resets in ...)" next to the Session meter — the reset epoch lands in the
+     *  same process-wide {@code ClaudeStatusStore} regardless of which view's data
+     *  channel supplied it, so this applies in both views. */
+    public static final String PREF_STATUSLINE_SHOW_SESSION_5H_RESET = "statuslineShowSession5hReset";
     public static final String PREF_STATUSLINE_SHOW_WEEKLY = "statuslineShowWeekly";
-    /** Show "(resets in ...)" next to the Session/Weekly meters, in both views —
-     *  the reset epoch lands in the same process-wide {@code ClaudeStatusStore}
-     *  regardless of which view's data channel supplied it. */
-    public static final String PREF_STATUSLINE_SHOW_RESETS = "statuslineShowResets";
+    /** Show "(resets in ...)" next to the Weekly meter (see PREF_STATUSLINE_SHOW_SESSION_5H_RESET). */
+    public static final String PREF_STATUSLINE_SHOW_WEEKLY_RESET = "statuslineShowWeeklyReset";
     /** Claude's idle re-run timer for the statusLine command, in seconds. */
     public static final String PREF_STATUSLINE_REFRESH_SECONDS = "statuslineRefreshSeconds";
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -1477,7 +1477,13 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         m.setOnToolStart(n -> display.asyncExec(() -> executeJS("window.onToolStart && window.onToolStart('" + tj + "','" + esc(n) + "')")));
         m.setOnThinking(t -> display.asyncExec(() -> executeJS("window.onThinking && window.onThinking('" + tj + "','" + esc(t) + "')")));
         m.setOnTokens(n -> display.asyncExec(() -> executeJS("window.onTokens && window.onTokens('" + tj + "','" + esc(n) + "')")));
-        m.setOnRateLimit(j -> display.asyncExec(() -> executeJS("window.onRateLimit && window.onRateLimit('" + tj + "','" + esc(j) + "')")));
+        m.setOnRateLimit(j -> {
+            ClaudeStatusStore.acceptRateLimitEvent(j);
+            display.asyncExec(() -> {
+                refreshStatusBar();
+                executeJS("window.onRateLimit && window.onRateLimit('" + tj + "','" + esc(j) + "')");
+            });
+        });
         m.setOnSessionId(id -> display.asyncExec(() -> executeJS("window.onSessionId && window.onSessionId('" + tj + "','" + esc(id) + "')")));
         m.setOnError(msg -> display.asyncExec(() -> executeJS("window.onError && window.onError('" + tj + "','" + esc(msg) + "')")));
         m.setOnCompact(j -> display.asyncExec(() -> executeJS("window.onCompact && window.onCompact('" + tj + "','" + esc(j) + "')")));

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -42,8 +42,9 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_CONTEXT, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_COST, false);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_SESSION_5H, true);
+        store.setDefault(Constants.PREF_STATUSLINE_SHOW_SESSION_5H_RESET, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY, true);
-        store.setDefault(Constants.PREF_STATUSLINE_SHOW_RESETS, true);
+        store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY_RESET, true);
         store.setDefault(Constants.PREF_STATUSLINE_REFRESH_SECONDS, 60);
 
         // Claude Code view spinner verbs — the three that were already in rotation

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -43,6 +43,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_COST, false);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_SESSION_5H, true);
         store.setDefault(Constants.PREF_STATUSLINE_SHOW_WEEKLY, true);
+        store.setDefault(Constants.PREF_STATUSLINE_SHOW_RESETS, true);
         store.setDefault(Constants.PREF_STATUSLINE_REFRESH_SECONDS, 60);
 
         // Claude Code view spinner verbs — the three that were already in rotation

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -200,6 +200,11 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 "Show weekly (7-day) usage limit",
                 getFieldEditorParent()));
 
+        addStatuslineDependent(new BooleanFieldEditor(
+                Constants.PREF_STATUSLINE_SHOW_RESETS,
+                "Show reset time for usage limits",
+                getFieldEditorParent()));
+
         IntegerFieldEditor refreshSeconds = new IntegerFieldEditor(
                 Constants.PREF_STATUSLINE_REFRESH_SECONDS,
                 "Status refresh interval (seconds; Terminal applies on next launch):",

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -196,13 +196,18 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 getFieldEditorParent()));
 
         addStatuslineDependent(new BooleanFieldEditor(
+                Constants.PREF_STATUSLINE_SHOW_SESSION_5H_RESET,
+                "Show reset time for 5-hour (session) usage limit",
+                getFieldEditorParent()));
+
+        addStatuslineDependent(new BooleanFieldEditor(
                 Constants.PREF_STATUSLINE_SHOW_WEEKLY,
                 "Show weekly (7-day) usage limit",
                 getFieldEditorParent()));
 
         addStatuslineDependent(new BooleanFieldEditor(
-                Constants.PREF_STATUSLINE_SHOW_RESETS,
-                "Show reset time for usage limits",
+                Constants.PREF_STATUSLINE_SHOW_WEEKLY_RESET,
+                "Show reset time for weekly (7-day) usage limit",
                 getFieldEditorParent()));
 
         IntegerFieldEditor refreshSeconds = new IntegerFieldEditor(

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
@@ -172,22 +172,22 @@ public final class ClaudeStatusBar extends Canvas {
 
         // Pick the widest form that fits: long → short → short with trailing groups dropped.
         //
-        // The long↔short decision is measured with reset text reserved (RESERVE_RESET_WIDTH,
-        // gated on the preference), even when a given status carries none, so the labels flip
-        // at the SAME window width in both views. Without that reservation a status lacking
-        // reset epochs measures narrower and keeps "Context/Session/Weekly" at widths where a
-        // status carrying "(resets in 2h 23m)" has already dropped to "C/S/W"; switching
-        // views/tabs then flips the labels back and forth for no visible reason. Rendering
-        // still uses the real data, so the reserved space simply goes unused when there is no
-        // reset time to draw. When the preference is off, no width is reserved either — resets
-        // never draw, so reserving space for them would just leave a permanent gap.
-        boolean showResets = Activator.getDefault().getPreferenceStore()
-                .getBoolean(Constants.PREF_STATUSLINE_SHOW_RESETS);
-        boolean compact =
-                totalWidth(buildSegments(gc, false, showResets, showResets && RESERVE_RESET_WIDTH)) > area.width;
-        SegLayout layout = buildSegments(gc, compact, showResets, MEASURE_ACTUAL);
+        // The long↔short decision is measured with reset text reserved per-meter
+        // (RESERVE_RESET_WIDTH, gated on that meter's own reset preference), even when a
+        // given status carries none, so the labels flip at the SAME window width in both
+        // views. Without that reservation a status lacking reset epochs measures narrower
+        // and keeps "Context/Session/Weekly" at widths where a status carrying "(resets in
+        // 2h 23m)" has already dropped to "C/S/W"; switching views/tabs then flips the
+        // labels back and forth for no visible reason. Rendering still uses the real data,
+        // so the reserved space simply goes unused when there is no reset time to draw.
+        // When a meter's own reset preference is off, no width is reserved for it either —
+        // its reset never draws, so reserving space for it would just leave a permanent gap.
+        boolean compact = totalWidth(buildSegments(gc, false, RESERVE_RESET_WIDTH, false)) > area.width;
+        SegLayout layout = buildSegments(gc, compact, MEASURE_ACTUAL, false);
         if (totalWidth(layout) > area.width) {
-            layout = buildSegments(gc, compact, false, MEASURE_ACTUAL);
+            // Still too wide: drop reset text (if any was showing) before dropping whole
+            // segments below — a meter with its percentage but no reset beats no meter.
+            layout = buildSegments(gc, compact, MEASURE_ACTUAL, true);
             dropToFit(layout, area.width);
         }
         draw(gc, layout, area.width, midY);
@@ -268,8 +268,8 @@ public final class ClaudeStatusBar extends Canvas {
     private static final String RESET_SAMPLE_LONG = "(resets in 23h 59m)";
     private static final String RESET_SAMPLE_SHORT = "(23h 59m)";
 
-    private SegLayout buildSegments(GC gc, boolean compact, boolean withResets,
-                                    boolean reserveResets) {
+    private SegLayout buildSegments(GC gc, boolean compact, boolean reserveResets,
+                                    boolean forceNoResets) {
         IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
         ClaudeStatus s = lastStatus;
         List<Seg> left = new ArrayList<>();
@@ -282,7 +282,7 @@ public final class ClaudeStatusBar extends Canvas {
             // Context never carries a reset time, so it never reserves width for one.
             left.add(buildMeter(gc, compact ? "C" : "Context",
                     s.contextUsedPercentage().orElse(0.0), true,
-                    OptionalLong.empty(), compact, withResets, false,
+                    OptionalLong.empty(), compact, false, false,
                     buildContextTooltip(s)));
         }
 
@@ -293,9 +293,11 @@ public final class ClaudeStatusBar extends Canvas {
         var five = s.fiveHour();
         if (prefs.getBoolean(Constants.PREF_STATUSLINE_SHOW_SESSION_5H)
                 && five.isPresent() && five.get().usedPercentage().isPresent()) {
+            boolean showReset = !forceNoResets
+                    && prefs.getBoolean(Constants.PREF_STATUSLINE_SHOW_SESSION_5H_RESET);
             right.add(buildMeter(gc, compact ? "S" : "Session",
                     five.get().usedPercentage().getAsDouble(), false,
-                    five.get().resetsAt(), compact, withResets, reserveResets,
+                    five.get().resetsAt(), compact, showReset, showReset && reserveResets,
                     buildLimitTooltip("5-hour session usage limit",
                             five.get().usedPercentage().getAsDouble(), five.get().resetsAt())));
         }
@@ -303,9 +305,11 @@ public final class ClaudeStatusBar extends Canvas {
         var seven = s.sevenDay();
         if (prefs.getBoolean(Constants.PREF_STATUSLINE_SHOW_WEEKLY)
                 && seven.isPresent() && seven.get().usedPercentage().isPresent()) {
+            boolean showReset = !forceNoResets
+                    && prefs.getBoolean(Constants.PREF_STATUSLINE_SHOW_WEEKLY_RESET);
             right.add(buildMeter(gc, compact ? "W" : "Weekly",
                     seven.get().usedPercentage().getAsDouble(), false,
-                    seven.get().resetsAt(), compact, withResets, reserveResets,
+                    seven.get().resetsAt(), compact, showReset, showReset && reserveResets,
                     buildLimitTooltip("Weekly usage limit",
                             seven.get().usedPercentage().getAsDouble(), seven.get().resetsAt())));
         }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusBar.java
@@ -172,18 +172,20 @@ public final class ClaudeStatusBar extends Canvas {
 
         // Pick the widest form that fits: long → short → short with trailing groups dropped.
         //
-        // The long↔short decision is measured with reset text ALWAYS reserved
-        // (RESERVE_RESET_WIDTH), even when this particular status carries none, so the
-        // labels flip at the SAME window width in both views. Without that reservation
-        // the Claude Code view — whose /usage probe supplies percentages but no reset
-        // epochs — measures narrower and keeps "Context/Session/Weekly" at widths where
-        // the Terminal, carrying "(resets in 2h 23m)", has already dropped to "C/S/W";
-        // switching views then flips the labels back and forth for no visible reason.
-        // Rendering still uses the real data, so the reserved space simply goes unused
-        // when there is no reset time to draw.
+        // The long↔short decision is measured with reset text reserved (RESERVE_RESET_WIDTH,
+        // gated on the preference), even when a given status carries none, so the labels flip
+        // at the SAME window width in both views. Without that reservation a status lacking
+        // reset epochs measures narrower and keeps "Context/Session/Weekly" at widths where a
+        // status carrying "(resets in 2h 23m)" has already dropped to "C/S/W"; switching
+        // views/tabs then flips the labels back and forth for no visible reason. Rendering
+        // still uses the real data, so the reserved space simply goes unused when there is no
+        // reset time to draw. When the preference is off, no width is reserved either — resets
+        // never draw, so reserving space for them would just leave a permanent gap.
+        boolean showResets = Activator.getDefault().getPreferenceStore()
+                .getBoolean(Constants.PREF_STATUSLINE_SHOW_RESETS);
         boolean compact =
-                totalWidth(buildSegments(gc, false, true, RESERVE_RESET_WIDTH)) > area.width;
-        SegLayout layout = buildSegments(gc, compact, true, MEASURE_ACTUAL);
+                totalWidth(buildSegments(gc, false, showResets, showResets && RESERVE_RESET_WIDTH)) > area.width;
+        SegLayout layout = buildSegments(gc, compact, showResets, MEASURE_ACTUAL);
         if (totalWidth(layout) > area.width) {
             layout = buildSegments(gc, compact, false, MEASURE_ACTUAL);
             dropToFit(layout, area.width);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusStore.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeStatusStore.java
@@ -1,6 +1,7 @@
 package com.anthropic.claudecode.eclipse.ui;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * Process-wide cache of the <em>account-global</em> status data — the 5-hour and
@@ -9,11 +10,16 @@ import com.google.gson.JsonObject;
  * identical everywhere; caching the latest observed value here is the single
  * source of truth both surfaces read from.
  *
- * <p>The only producer is the CLI statusLine (Claude does not emit usage
- * percentages in the GUI's headless {@code -p} stream). The data is fed in via a
- * non-invasive decorator around the status-callback registration, so the
- * contributor's {@code StatusBridge}/{@code ClaudeStatusBar}/{@code ClaudeStatus}
- * classes are never touched. It reuses {@link ClaudeStatus#parse} read-only.
+ * <p>Two producers feed this store. The CLI statusLine ({@link #acceptStatusLine})
+ * supplies percentage <em>and</em> reset epoch, and is the only source in the Claude
+ * Terminal view. The Claude GUI view has no equivalent live channel — its {@code /usage}
+ * probe supplies percentage only (that command reports reset times as localized prose,
+ * which is deliberately not parsed) — so it additionally feeds the {@code
+ * rate_limit_event} stream ({@link #acceptRateLimitEvent}), which carries a structured
+ * reset epoch for exactly one window per event. The data is fed in via a non-invasive
+ * decorator around the status-callback registration, so the contributor's {@code
+ * StatusBridge}/{@code ClaudeStatusBar}/{@code ClaudeStatus} classes are never touched.
+ * It reuses {@link ClaudeStatus#parse} read-only.
  *
  * <p>Thread-safe: a single {@code volatile} reference to an immutable snapshot.
  */
@@ -38,6 +44,46 @@ public final class ClaudeStatusStore {
             if (s.fiveHour().isPresent() || s.sevenDay().isPresent()) {
                 latest = merge(latest, s);
             }
+        } catch (Exception ignored) {}
+    }
+
+    /**
+     * Accepts a raw {@code rate_limit_event} JSON payload (from the CLI's
+     * {@code onRateLimit} stream). This event carries a structured reset epoch for
+     * exactly one window at a time ({@code rateLimitType}: {@code "five_hour"} or
+     * {@code "seven_day"} — matched loosely, the same way the GUI's own usage banner
+     * already does), but never a usage percentage. Never throws — a bad or
+     * unrecognized document is ignored.
+     */
+    public static void acceptRateLimitEvent(String rateLimitJson) {
+        try {
+            com.google.gson.JsonElement el = JsonParser.parseString(rateLimitJson);
+            if (!el.isJsonObject()) return;
+            JsonObject info = el.getAsJsonObject();
+            com.google.gson.JsonElement resetsAtEl = info.get("resetsAt");
+            if (resetsAtEl == null || !resetsAtEl.isJsonPrimitive()) return;
+            String type = info.has("rateLimitType") && info.get("rateLimitType").isJsonPrimitive()
+                    ? info.get("rateLimitType").getAsString() : "";
+            String key;
+            if (type.matches("(?i).*five.*")) {
+                key = "five_hour";
+            } else if (type.matches("(?i).*seven.*")) {
+                key = "seven_day";
+            } else {
+                // Unrecognized/missing window — don't guess which meter it belongs to.
+                return;
+            }
+
+            JsonObject window = new JsonObject();
+            window.addProperty("resets_at", resetsAtEl.getAsLong());
+            JsonObject limits = new JsonObject();
+            limits.add(key, window);
+            JsonObject root = new JsonObject();
+            root.add("rate_limits", limits);
+
+            ClaudeStatus s = ClaudeStatus.parse(root.toString());
+            if (s == null) return;
+            latest = merge(latest, s);
         } catch (Exception ignored) {}
     }
 
@@ -68,12 +114,31 @@ public final class ClaudeStatusStore {
     private static void mergeWindow(JsonObject out, String key,
                                     java.util.Optional<ClaudeStatus.RateLimit> prev,
                                     java.util.Optional<ClaudeStatus.RateLimit> next) {
-        // Nothing new for this window: keep whatever we already knew.
-        if (next.isEmpty() || next.get().usedPercentage().isEmpty()) {
+        if (next.isEmpty()) {
             addWindow(out, key, prev);
             return;
         }
         ClaudeStatus.RateLimit n = next.get();
+        if (n.usedPercentage().isEmpty()) {
+            // A rate_limit_event fragment: reset epoch only, no percentage. Keep the
+            // last known percentage (if any) and take the new reset — the inverse of
+            // the case below, where a percentage-only snapshot inherits an old reset.
+            if (n.resetsAt().isEmpty()) {
+                addWindow(out, key, prev);
+                return;
+            }
+            JsonObject w = new JsonObject();
+            if (prev.isPresent() && prev.get().usedPercentage().isPresent()) {
+                w.addProperty("used_percentage", prev.get().usedPercentage().getAsDouble());
+            }
+            // No percentage yet: still record the reset alone so it survives to be
+            // paired with a percentage arriving later (e.g. from the /usage probe) —
+            // addWindow() already hides a percentage-less window from the bar, so
+            // this is invisible until then, not a premature partial render.
+            w.addProperty("resets_at", n.resetsAt().getAsLong());
+            out.add(key, w);
+            return;
+        }
         JsonObject w = new JsonObject();
         w.addProperty("used_percentage", n.usedPercentage().getAsDouble());
         if (n.resetsAt().isPresent()) {


### PR DESCRIPTION
Splits "show reset time" out as its own preference for each usage meter (5-hour session and weekly), shown next to the existing limit percentage.

Shows when each usage limit recovers, not just how full it is.