### PR TITLE
Add a preference to hide the working-directory row

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/supertabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/supertabs.js
@@ -24,6 +24,17 @@
 /** @type {Root[]} */
 let roots = [], activeRootId = null, rootSeq = 0;
 let supertabsVisible = true;
+// PREF_HIDE_ROOT_DIRECTORIES_ROW (Preferences > Claude Code): hides the root row AND
+// its collapsed #cwd-row stand-in AND the toolbar's "show it again" chevron — the whole
+// feature disappears, not just the row supertabsVisible already toggles per-session.
+// Distinct from supertabsVisible: that one still leaves a way back (the collapsed
+// chevron); this one is a deliberate "I only ever use one folder" opt-out with no
+// in-page way to bring it back, matching a real preference rather than a session toggle.
+let rootDirectoriesRowHidden = false;
+window.onHideRootDirectoriesRow = function(hide) {
+  rootDirectoriesRowHidden = !!hide;
+  renderSupertabs();
+};
 
 /** @returns {Root|null} */
 function activeRoot() { return roots.find(r => r.id === activeRootId) || null; }
@@ -172,12 +183,14 @@ function moveRoot(fromId, toId, after) {
 }
 function renderSupertabs() {
   const row = document.getElementById('supertab-row');
-  if (row) row.style.display = supertabsVisible ? '' : 'none';
+  if (row) row.style.display = (supertabsVisible && !rootDirectoriesRowHidden) ? '' : 'none';
   // Exactly one of the two is up at any time, so both are driven from here — giving
   // the strip its own toggle path is how they end up both visible or both hidden.
+  // Both stay hidden when the preference is on: the whole feature is gone, not just
+  // collapsed to its "which folder am I in" stand-in.
   const cwd = document.getElementById('cwd-row');
   if (cwd) {
-    cwd.style.display = supertabsVisible ? 'none' : 'flex';
+    cwd.style.display = (!supertabsVisible && !rootDirectoriesRowHidden) ? 'flex' : 'none';
     const ar = activeRoot();
     cwd.querySelector('.ct').textContent = ar ? ar.name : '';
     cwd.title = ar ? ar.path : '';
@@ -247,7 +260,9 @@ function syncSupertabToggle() {
   if (inBar) {
     inBar.innerHTML = ICONS.CHEVUP;                   // hidden → points up
     inBar.title = 'Show root directories';
-    inBar.style.display = supertabsVisible ? 'none' : '';
+    // Never shown at all when the preference hides the feature outright — there is
+    // deliberately no in-page way back (see rootDirectoriesRowHidden's own comment).
+    inBar.style.display = (supertabsVisible || rootDirectoriesRowHidden) ? 'none' : '';
   }
 }
 function toggleSupertabs() {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -70,6 +70,14 @@ public final class Constants {
     /** Claude's idle re-run timer for the statusLine command, in seconds. */
     public static final String PREF_STATUSLINE_REFRESH_SECONDS = "statuslineRefreshSeconds";
 
+    /** Hide the root ("supertab") directory row entirely, in the Claude Code view —
+     *  no picker, no per-session show/hide toggle (supertabsVisible), nothing. For a
+     *  user who only ever works in one folder, the row (plus the toggle's own collapsed
+     *  #cwd-row stand-in) is pure vertical space spent on a feature they never use. Off
+     *  by default: multi-root conversations are the new upstream behavior, and this is
+     *  an opt-out, not the other way around. */
+    public static final String PREF_HIDE_ROOT_DIRECTORIES_ROW = "hideRootDirectoriesRow";
+
     // ── Spinner verbs ───────────────────────────────────────────────────────
     // Which optional slices of the working-indicator gerund list are in rotation.
     // Each names a membership set over the single master list in working.js

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -150,6 +150,8 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     private ClaudeStatusBar statusBar;
     // Live-applies PREF_STATUSLINE_* changes (enable/toggles/refresh) without a restart.
     private org.eclipse.jface.util.IPropertyChangeListener statusPrefListener;
+    // Live-applies PREF_HIDE_ROOT_DIRECTORIES_ROW changes without a restart or page reload.
+    private org.eclipse.jface.util.IPropertyChangeListener hideRootRowPrefListener;
     // Re-pushes light/dark to the webview when the Eclipse workbench theme changes.
     private org.eclipse.jface.util.IPropertyChangeListener themeChangeListener;
     // Re-pushes the right-click menu's key hints when the user's bindings change.
@@ -220,6 +222,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // this view sees them without having to send a turn first (issue #99).
         fetchUsageAsync();
         registerStatusPrefListener();
+        registerHideRootRowPrefListener();
         registerThemeListener();
         registerBindingListener();
         registerEditHandlers();
@@ -571,6 +574,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             pushCliModels();         // ditto for the installed binary's model support
             pushEditKeyHints();      // label the right-click menu with the user's real keys
             pushDebugMode();         // let the page report its keys while Debug mode is on
+            pushHideRootDirectoriesRow(); // whether the root directories row is hidden entirely
             pushSpinnerVerbs();      // which gerund categories the working indicator cycles
             // An "Open Claude Code Here" that arrived while the view was still loading.
             String queuedRoot = pendingRootPath;
@@ -953,6 +957,16 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         Activator.getDefault().getPreferenceStore().addPropertyChangeListener(statusPrefListener);
     }
 
+    /** Live-applies a Preferences change to "hide root directories row" without needing a
+     *  page reload — mirrors {@link #registerStatusPrefListener()}. */
+    private void registerHideRootRowPrefListener() {
+        hideRootRowPrefListener = event -> {
+            if (!com.anthropic.claudecode.eclipse.Constants.PREF_HIDE_ROOT_DIRECTORIES_ROW.equals(event.getProperty())) return;
+            Display.getDefault().asyncExec(this::pushHideRootDirectoriesRow);
+        };
+        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(hideRootRowPrefListener);
+    }
+
     /**
      * Live theme refresh driven by the JFace {@link org.eclipse.jface.resource.ColorRegistry},
      * the SAME signal that recolors the shared status bar the instant the Eclipse theme changes
@@ -1292,6 +1306,20 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     private void pushDebugMode() {
         if (browser == null || browser.isDisposed() || !pageLoaded) return;
         browser.execute("window.__ccDebug = " + DebugModeUi.isDebugEnabled() + ";");
+    }
+
+    /**
+     * Tells the page whether to hide the root ("supertab") directory row entirely.
+     * Re-pushed on activation and on every live Preferences change (see
+     * {@link #registerHideRootRowPrefListener()}). Calls into the page's own
+     * {@code renderSupertabs()} area rather than just setting a flag, since hiding the
+     * row has to take effect immediately — see {@code window.onHideRootDirectoriesRow}.
+     */
+    private void pushHideRootDirectoriesRow() {
+        if (browser == null || browser.isDisposed() || !pageLoaded) return;
+        boolean hide = Activator.getDefault().getPreferenceStore()
+                .getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_HIDE_ROOT_DIRECTORIES_ROW);
+        browser.execute("window.onHideRootDirectoriesRow && window.onHideRootDirectoriesRow(" + hide + ")");
     }
 
     /**
@@ -1918,6 +1946,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // change shows up in the right-click menu's hints on the next activation.
         pushEditKeyHints();
         pushDebugMode();
+        pushHideRootDirectoriesRow();
         pushSpinnerVerbs();
     }
 
@@ -2384,6 +2413,11 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(statusPrefListener); }
             catch (Throwable ignored) {}
             statusPrefListener = null;
+        }
+        if (hideRootRowPrefListener != null) {
+            try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(hideRootRowPrefListener); }
+            catch (Throwable ignored) {}
+            hideRootRowPrefListener = null;
         }
         if (themeChangeListener != null) {
             try {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -47,6 +47,8 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
 
         // Claude Code view spinner verbs — the three that were already in rotation
         // stay on; dank and the vibecoder claim are opt-in.
+        store.setDefault(Constants.PREF_HIDE_ROOT_DIRECTORIES_ROW, false);
+
         store.setDefault(Constants.PREF_SPINNER_DEPRECATED, true);
         store.setDefault(Constants.PREF_SPINNER_PACK_ONE, true);
         store.setDefault(Constants.PREF_SPINNER_PACK_TWO, true);

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -254,6 +254,11 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
         miscLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 
         addField(new BooleanFieldEditor(
+                Constants.PREF_HIDE_ROOT_DIRECTORIES_ROW,
+                "Hide the root directories row, in the Claude Code view (for single-folder use)",
+                getFieldEditorParent()));
+
+        addField(new BooleanFieldEditor(
                 Constants.PREF_SPINNER_DEPRECATED,
                 "Use deprecated spinner verbs",
                 getFieldEditorParent()));


### PR DESCRIPTION
Adds a preference to fully hide the row used for picking which folder a conversation runs in, including its collapsed stand-in and toolbar toggle.

Gives that screen space back to anyone who only ever works in a single folder.