### PR TITLE
Add a "Smart" Scroll Lock that still follows your own actions

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/advisor.js
@@ -91,7 +91,8 @@ function openAdvisorCard(echoText) {
     if (echoText) addUserMessage(echoText, null, null, null, nowIso());
     // Target the active tab: addSystem() would follow the render tab instead.
     addSystemTo(activeTab(), value ? 'Advisor set to ' + label + '.' : 'Advisor disabled.');
-    scrollBottom();
+    // force only with Smart Scroll Lock on — see its comment in chat.js.
+    scrollBottom(smartScrollLock);
   }
   function paint() {
     card.querySelectorAll('.dec-opt').forEach((el, j) => el.classList.toggle('sel', j === sel));

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/cards.js
@@ -176,7 +176,9 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
       finalizeThink(); curBody = null; curText = '';
       showWorking();
     }
-    scrollBottom();   // obeys Scroll Lock — answering must not move them either
+    // force only with Smart Scroll Lock on — see its comment in chat.js. By default
+    // this obeys Scroll Lock: answering must not move them either.
+    scrollBottom(smartScrollLock);
   }
 
   // Middle "remember" option is contextual: its label comes from the CLI's own
@@ -266,6 +268,8 @@ window.onApprovalRequest = function(tabId, reqId, toolName, detail, rememberLabe
   });
 
   showBottomCard(card, owner);
+  // force only with Smart Scroll Lock on — see its comment in chat.js.
+  scrollBottom(smartScrollLock);
 };
 
 /* ---- AskUserQuestion card (single/multi question, options + Other) ---- */
@@ -328,7 +332,8 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     if (window._answerQuestion) window._answerQuestion(reqId, JSON.stringify(answers));
     clearBottomCard(owner);
     const summary = answers.map(a => questions.length > 1 ? (a.header + ': ' + a.answer) : a.answer).join('\n');
-    addAnswered(summary, pane); startFreshTurn(); scrollBottom();   // obeys Scroll Lock
+    // force only with Smart Scroll Lock on — see its comment in chat.js.
+    addAnswered(summary, pane); startFreshTurn(); scrollBottom(smartScrollLock);
   }
   function cancel() {
     if (resolved) return; resolved = true;
@@ -337,7 +342,8 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
     document.removeEventListener('keydown', onKey, true);
     resolveDot(true);
     if (window._answerQuestion) window._answerQuestion(reqId, '[]');
-    clearBottomCard(owner); scrollBottom();   // obeys Scroll Lock
+    // force only with Smart Scroll Lock on — see its comment in chat.js.
+    clearBottomCard(owner); scrollBottom(smartScrollLock);
   }
 
   function render() {
@@ -464,5 +470,7 @@ window.onAskQuestion = function(tabId, reqId, questionsJson) {
   });
 
   render(); showBottomCard(card, owner);
+  // force only with Smart Scroll Lock on — see its comment in chat.js.
+  scrollBottom(smartScrollLock);
 };
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -13,7 +13,12 @@ function clearWelcome(pane) { if (!pane) return; const w = pane.querySelector('.
      off  → the transcript always scrolls to the bottom on every render (the original
             behavior, untouched).
      on   → it scrolls only while you are already at the bottom. Scroll up to read and
-            it holds; scroll back down and it resumes on its own.
+            it holds; scroll back down and it resumes on its own. Exception: with Smart
+            Scroll Lock also on (a separate preference, see smartScrollLock below), your
+            OWN deliberate actions — sending a message, answering an approval or question
+            card — still jump you to the bottom, and so does Claude raising a NEW
+            approval or question card (the session is blocked until it's answered); a
+            card timing out on its own does not.
 
    View-wide, not per-tab: #messages is a single scroll container shared by every tab's
    pane (chat.css), so one toggle governs every conversation in the view. Java owns the
@@ -25,6 +30,14 @@ window.onScrollLock = function(locked) {
   // Both edges: unlocking has to retire the button now, not at the next render.
   updateJumpToLatest();
 };
+// Smart Scroll Lock (Preferences > Claude Code): while the lock is armed, still jump to
+// the bottom for the user's OWN deliberate actions (sending a message, answering a card)
+// AND when Claude raises a new approval/question card, instead of holding through those
+// too — see scrollBottom's `force` param and its call sites in cards.js/chat.js. A card
+// timing out on its own is excluded, matching the plugin's pre-Scroll-Lock behavior. Off
+// matches the plugin's current upstream behavior (the lock holds through everything).
+let smartScrollLock = false;
+window.onSmartScrollLock = function(smart) { smartScrollLock = !!smart; };
 // How far from the true bottom still counts as "at the bottom" for the purpose of
 // (re-)arming followTail — has to clear the viewport settling on first render
 // (scrollHeight starts equal to clientHeight before any content), not a streamed
@@ -155,11 +168,13 @@ function addUserMessage(text, ctx, images, id, ts) {
     box.appendChild(body);
   }
   turn.appendChild(box); pane.appendChild(turn);
-  // NOT scrollBottom(true): with the lock armed, sending must not move the view either.
-  // The lock means "leave my scroll position alone" without exception — being thrown to
-  // the bottom by your own message is the same interruption as being thrown there by a
-  // streamed chunk. Unlocked, this still jumps to the bottom as it always did.
-  scrollBottom();
+  // force only with Smart Scroll Lock on: by default, with the lock armed, sending must
+  // not move the view either — the lock means "leave my scroll position alone" without
+  // exception, being thrown to the bottom by your own message is the same interruption
+  // as being thrown there by a streamed chunk. Smart Scroll Lock opts into the opposite
+  // read: your OWN deliberate action is expected to land you at the bottom. Unlocked,
+  // this jumps to the bottom either way, as it always did.
+  scrollBottom(smartScrollLock);
 }
 // Lazily create the assistant turn — only when real content (text or a tool)
 // arrives. While Claude is just "thinking", nothing but the working sunburst shows.

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -30,6 +30,14 @@ public final class Constants {
      *  newly created view instance — a configured default, not a remembered last state. */
     public static final String PREF_SCROLL_LOCK_DEFAULT = "scrollLockDefault";
 
+    /** In the Claude Code (GUI) view, while Scroll Lock is armed, still jump to the bottom
+     *  for the user's OWN deliberate actions (sending a message, answering an approval or
+     *  question card) and when Claude raises a NEW approval or question card, rather than
+     *  holding through those too. A card timing out on its own is NOT one of these — that
+     *  was never forced even before Scroll Lock existed. Off matches the plugin's current
+     *  upstream behavior. Terminal view has no equivalent. */
+    public static final String PREF_SMART_SCROLL_LOCK = "smartScrollLock";
+
     /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */
     public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -26,8 +26,11 @@ public final class Constants {
     public static final String PREF_TERMINAL_POSITION = "terminalPosition";
     public static final String PREF_DEBUG_MODE = "debugMode";
 
-    /** Initial state of the Claude Code (GUI) view's Scroll Lock toolbar toggle for a
-     *  newly created view instance — a configured default, not a remembered last state. */
+    /** Initial state of the Scroll Lock toolbar toggle for a newly created view instance —
+     *  a configured default, not a remembered last state. Shared by both the Claude Code
+     *  (GUI) view (ClaudeGuiView#createToolBar, one view-wide toggle) and the Claude
+     *  Terminal view (ClaudeCliView#configureActionBars, applied to each new tab's own
+     *  TerminalSession — see the per-tab isScrollLock/setScrollLock there). */
     public static final String PREF_SCROLL_LOCK_DEFAULT = "scrollLockDefault";
 
     /** In the Claude Code (GUI) view, while Scroll Lock is armed, still jump to the bottom
@@ -35,7 +38,10 @@ public final class Constants {
      *  question card) and when Claude raises a NEW approval or question card, rather than
      *  holding through those too. A card timing out on its own is NOT one of these — that
      *  was never forced even before Scroll Lock existed. Off matches the plugin's current
-     *  upstream behavior. Terminal view has no equivalent. */
+     *  upstream behavior.
+     *
+     *  <p>GUI view only by design — Terminal's Scroll Lock is TM Terminal's own viewport
+     *  freeze, with no "user sent input" seam to hook a bypass onto. */
     public static final String PREF_SMART_SCROLL_LOCK = "smartScrollLock";
 
     /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -26,6 +26,10 @@ public final class Constants {
     public static final String PREF_TERMINAL_POSITION = "terminalPosition";
     public static final String PREF_DEBUG_MODE = "debugMode";
 
+    /** Initial state of the Claude Code (GUI) view's Scroll Lock toolbar toggle for a
+     *  newly created view instance — a configured default, not a remembered last state. */
+    public static final String PREF_SCROLL_LOCK_DEFAULT = "scrollLockDefault";
+
     /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */
     public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -373,6 +373,12 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         };
         scrollLockAction.setToolTipText("Scroll Lock");
         scrollLockAction.setImageDescriptor(Activator.getImageDescriptor(Constants.IMG_SCROLL_LOCK));
+        // A configured default for a newly created view instance (Preferences > Claude
+        // Code; shared with ClaudeGuiView#createToolBar), not a remembered last state.
+        // Every session created afterwards (openNewSession) reads THIS action's checked
+        // state, not the preference directly, so setting it here alone covers them all.
+        scrollLockAction.setChecked(Activator.getDefault().getPreferenceStore()
+                .getBoolean(Constants.PREF_SCROLL_LOCK_DEFAULT));
         toolBar.add(scrollLockAction);
     }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -670,6 +670,10 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         scrollLockAction.setToolTipText("Scroll Lock");
         scrollLockAction.setImageDescriptor(Activator.getImageDescriptor(
                 com.anthropic.claudecode.eclipse.Constants.IMG_SCROLL_LOCK));
+        // A configured default for a newly created view instance (Preferences > Claude
+        // Code), not a remembered last state — every new view starts from this setting.
+        scrollLockAction.setChecked(Activator.getDefault().getPreferenceStore()
+                .getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_SCROLL_LOCK_DEFAULT));
         toolBar.add(scrollLockAction);
     }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -154,6 +154,8 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     private org.eclipse.jface.util.IPropertyChangeListener historyShowTimestampsPrefListener;
     // Live-applies PREF_HIDE_ROOT_DIRECTORIES_ROW changes without a restart or page reload.
     private org.eclipse.jface.util.IPropertyChangeListener hideRootRowPrefListener;
+    // Live-applies PREF_SMART_SCROLL_LOCK changes without a restart or page reload.
+    private org.eclipse.jface.util.IPropertyChangeListener smartScrollLockPrefListener;
     // Re-pushes light/dark to the webview when the Eclipse workbench theme changes.
     private org.eclipse.jface.util.IPropertyChangeListener themeChangeListener;
     // Re-pushes the right-click menu's key hints when the user's bindings change.
@@ -226,6 +228,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         registerStatusPrefListener();
         registerHistoryShowTimestampsPrefListener();
         registerHideRootRowPrefListener();
+        registerSmartScrollLockPrefListener();
         registerThemeListener();
         registerBindingListener();
         registerEditHandlers();
@@ -584,6 +587,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             String queuedRoot = pendingRootPath;
             if (queuedRoot != null) { pendingRootPath = null; openRootDirectory(queuedRoot); }
             pushScrollLock();        // the toolbar toggle outlives the page — re-apply it
+            pushSmartScrollLock();   // ditto for the Smart Scroll Lock preference
             for (int ms : new int[]{50, 200, 500, 1000, 1500}) {
                 Display.getCurrent().timerExec(ms, this::activateInput);
                 // Re-push the theme too: the root composite's CSS-themed background may not
@@ -687,6 +691,17 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         if (browser == null || browser.isDisposed() || !pageLoaded) return;
         boolean locked = scrollLockAction != null && scrollLockAction.isChecked();
         browser.execute("window.onScrollLock && window.onScrollLock(" + locked + ")");
+    }
+
+    /** Pushes the Smart Scroll Lock preference into the webview. Called on page load
+     *  AND on every live Preferences change (see {@link #registerSmartScrollLockPrefListener()}) —
+     *  a Preferences dialog OK doesn't reload the page, so without the live push a mid-session
+     *  toggle wouldn't take effect until the view was recreated. */
+    private void pushSmartScrollLock() {
+        if (browser == null || browser.isDisposed() || !pageLoaded) return;
+        boolean smart = Activator.getDefault().getPreferenceStore()
+                .getBoolean(com.anthropic.claudecode.eclipse.Constants.PREF_SMART_SCROLL_LOCK);
+        browser.execute("window.onSmartScrollLock && window.onSmartScrollLock(" + smart + ")");
     }
 
     /** Resolves installed-vs-latest CLI versions and pushes the result to the webview. */
@@ -1100,6 +1115,16 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             Display.getDefault().asyncExec(this::pushHideRootDirectoriesRow);
         };
         Activator.getDefault().getPreferenceStore().addPropertyChangeListener(hideRootRowPrefListener);
+    }
+
+    /** Live-applies a Preferences change to Smart Scroll Lock without needing a page
+     *  reload — mirrors {@link #registerStatusPrefListener()}. */
+    private void registerSmartScrollLockPrefListener() {
+        smartScrollLockPrefListener = event -> {
+            if (!com.anthropic.claudecode.eclipse.Constants.PREF_SMART_SCROLL_LOCK.equals(event.getProperty())) return;
+            Display.getDefault().asyncExec(this::pushSmartScrollLock);
+        };
+        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(smartScrollLockPrefListener);
     }
 
     /**
@@ -2580,6 +2605,11 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(hideRootRowPrefListener); }
             catch (Throwable ignored) {}
             hideRootRowPrefListener = null;
+        }
+        if (smartScrollLockPrefListener != null) {
+            try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(smartScrollLockPrefListener); }
+            catch (Throwable ignored) {}
+            smartScrollLockPrefListener = null;
         }
         if (themeChangeListener != null) {
             try {

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -22,6 +22,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_TERMINAL_POSITION, "bottom");
         store.setDefault(Constants.PREF_DEBUG_MODE, false);
         store.setDefault(Constants.PREF_SCROLL_LOCK_DEFAULT, false);
+        store.setDefault(Constants.PREF_SMART_SCROLL_LOCK, false);
         store.setDefault(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, false);
 
         store.setDefault(Constants.PREF_HTTP_PROXY, "");

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -21,6 +21,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_TRACK_SELECTION, true);
         store.setDefault(Constants.PREF_TERMINAL_POSITION, "bottom");
         store.setDefault(Constants.PREF_DEBUG_MODE, false);
+        store.setDefault(Constants.PREF_SCROLL_LOCK_DEFAULT, false);
         store.setDefault(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, false);
 
         store.setDefault(Constants.PREF_HTTP_PROXY, "");

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -157,6 +157,13 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 "Scroll Lock enabled by default in the Claude Code view",
                 getFieldEditorParent()));
 
+        addField(new BooleanFieldEditor(
+                Constants.PREF_SMART_SCROLL_LOCK,
+                "Smart Scroll Lock: in the Claude Code view, still jump to the bottom for "
+                        + "your own actions (sending a message, answering a card) even while "
+                        + "Scroll Lock is on",
+                getFieldEditorParent()));
+
         Label statusSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);
         statusSeparator.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -154,7 +154,7 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
 
         addField(new BooleanFieldEditor(
                 Constants.PREF_SCROLL_LOCK_DEFAULT,
-                "Scroll Lock enabled by default in the Claude Code view",
+                "Scroll Lock enabled by default (Claude Code and Claude Terminal views)",
                 getFieldEditorParent()));
 
         addField(new BooleanFieldEditor(

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -152,6 +152,11 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 "Debug mode",
                 getFieldEditorParent()));
 
+        addField(new BooleanFieldEditor(
+                Constants.PREF_SCROLL_LOCK_DEFAULT,
+                "Scroll Lock enabled by default in the Claude Code view",
+                getFieldEditorParent()));
+
         Label statusSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);
         statusSeparator.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 


### PR DESCRIPTION
Adds a preference for Scroll Lock's default on/off state when a view is first opened, shared by both the Claude Code and Claude Terminal views.

Adds a "Smart" Scroll Lock preference, Claude Code view only. Scroll Lock normally holds your scroll position no matter what — reading back through a long response without getting pulled to the bottom. With Smart Scroll Lock also on, three things still jump you to the bottom: sending a message, answering an approval or question card, and Claude raising a new one (the session is blocked until you answer it anyway).

Smart Scroll Lock only applies to the Claude Code view. Claude Terminal's Scroll Lock is a different mechanism — a native terminal viewport freeze rather than custom rendering code — with no equivalent way to make an exception for a specific action.

Being able to set Scroll Lock's own starting state (the first preference above) saves a manual toggle every time either view opens and makes particular sense with "Smart" Scroll Lock on.