### PR TITLE
Consolidate the panel's actions into the Eclipse toolbar

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -50,14 +50,13 @@
   </div>
 
   <!-- Conversation header -->
+  <!-- New session / Session history moved to the native Eclipse view toolbar
+       (ClaudeGuiView#createToolBar), matching the Claude Terminal view's own
+       toolbar layout — this row now holds only the editable title. -->
   <div id="convo-header">
     <div class="title-wrap" id="title-wrap" onclick="startTitleEdit()">
       <span class="title" id="convo-title">Claude Code</span>
       <span class="title-edit" id="title-edit" title="Rename">__PENCIL__</span>
-    </div>
-    <div class="actions">
-      <div class="tbtn" id="history-btn" title="Session history" onclick="toggleHistory(this)">__CLOCK__</div>
-      <div class="tbtn" title="New session" onclick="newSession()">__NEWCHAT__</div>
     </div>
   </div>
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -49,17 +49,6 @@
     </div>
   </div>
 
-  <!-- Conversation header -->
-  <!-- New session / Session history moved to the native Eclipse view toolbar
-       (ClaudeGuiView#createToolBar), matching the Claude Terminal view's own
-       toolbar layout — this row now holds only the editable title. -->
-  <div id="convo-header">
-    <div class="title-wrap" id="title-wrap" onclick="startTitleEdit()">
-      <span class="title" id="convo-title">Claude Code</span>
-      <span class="title-edit" id="title-edit" title="Rename">__PENCIL__</span>
-    </div>
-  </div>
-
   <!-- CLI update banner (shown only when the installed Claude Code is outdated) -->
   <div id="update-banner">
     <span class="ub-ic">__BOLT__</span>

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -69,6 +69,36 @@ window.onHistoryLoaded = function(json) {
   histLoaded = true; setHistoryLoading(false); renderHistoryList();
   clampOpenMenu();   // the list may be a different width than "Loading…" — re-pin so it isn't cut off
 };
+// True while the history panel is open FOR /resume specifically — picking an item
+// then loads it into the CURRENT tab (in place) instead of opening a new one. Set ONLY
+// on openHistoryPanel's success path (never on the "already open → just close" path,
+// where no panel ends up open at all) and consumed exactly once by loadHistory(),
+// which resets it immediately — so it can never outlive a single open→pick cycle or
+// leak into some later, unrelated opening of the same panel.
+let historyResumeInPlace = false;
+
+/* Shared panel-opening logic for both entry points below. Toggles: calling this while
+ * already open just closes the panel (matches both callers' own "click it again to
+ * close" expectations) rather than reopening/repositioning it.
+ * @param {boolean} resumeInPlace this opening's historyResumeInPlace value — only takes
+ *   effect if a panel actually ends up open (see historyResumeInPlace's own comment). */
+function openHistoryPanel(resumeInPlace) {
+  const panel = document.getElementById('history-panel');
+  const wasOpen = panel.classList.contains('open');
+  closeMenus();
+  if (wasOpen) return false;
+  historyResumeInPlace = resumeInPlace;
+  histTab('local');
+  const s = document.getElementById('hist-search'); if (s) s.value = '';
+  // Open the panel immediately; show cached results if we have them, otherwise a
+  // "Loading…" state — and (re)load in the background either way.
+  renderHistoryList();
+  loadHistoryAsync();
+  panel.classList.add('open');
+  if (s) setTimeout(() => s.focus(), 0);
+  return true;
+}
+
 /* Called from the native Eclipse view toolbar's "Session history" Action
  * (ClaudeGuiView#createToolBar → pushToolbarAction) — that button lives outside the
  * webview entirely, so there's no in-page anchor element to glue the panel to the
@@ -80,22 +110,39 @@ window.onHistoryLoaded = function(json) {
  * ENTIRE reaction to that click, so wasOpen faithfully reflects the panel's state
  * from just before this call, with no risk of that other listener having already
  * closed it first.
+ *
+ * Picking an item here opens a NEW tab — matches the Claude Terminal view's own
+ * Session History button, which always opens a new tab too (--resume is a launch
+ * flag, its only option). See openHistoryForResume for the other entry point.
  */
 window.openHistoryFromToolbar = function() {
   const panel = document.getElementById('history-panel');
-  const wasOpen = panel.classList.contains('open');
-  closeMenus();
-  if (wasOpen) return;
-  histTab('local');
-  const s = document.getElementById('hist-search'); if (s) s.value = '';
-  // Open the panel immediately; show cached results if we have them, otherwise a
-  // "Loading…" state — and (re)load in the background either way.
-  renderHistoryList();
-  loadHistoryAsync();
-  panel.classList.add('open');
+  if (!openHistoryPanel(false)) return;
   positionMenuFixed(panel);
   openMenuEl = panel;   // openAnchor stays null — nothing in-page to re-anchor to
-  if (s) setTimeout(() => s.focus(), 0);
+};
+
+/* Called from the /resume composer slash command (slash.js) — this one deliberately
+ * behaves like the CLI's OWN /resume typed at an existing Claude Terminal prompt:
+ * picking a session swaps the CURRENT tab's conversation in place, not a new tab.
+ * /resume is something you type INTO a specific conversation ("change what THIS is"),
+ * unlike the toolbar button's generic "browse history" with no current-tab context —
+ * the two are allowed to differ on purpose; see loadHistory's historyResumeInPlace
+ * branch for where this actually takes effect.
+ *
+ * Positioned the SAME way as the toolbar's own opening (positionMenuFixed, top-right
+ * of the viewport) rather than anchored to #slash-btn: that button sits in the
+ * composer at the BOTTOM of the view, and positionMenu's below/right rules (hardcoded
+ * per menu id, see its own comment) drop history-panel BELOW its anchor — for a
+ * bottom-of-page trigger that means off the bottom edge, clamped back up into
+ * overlapping the composer instead of rising above it like #modes-menu does. Where
+ * the panel appears from doesn't need to encode which entry point opened it.
+ */
+window.openHistoryForResume = function() {
+  const panel = document.getElementById('history-panel');
+  if (!openHistoryPanel(true)) return;
+  positionMenuFixed(panel);
+  openMenuEl = panel;   // openAnchor stays null — nothing in-page to re-anchor to
 };
 function histTab(which) {
   const local = which === 'local';
@@ -206,34 +253,53 @@ function appendTextStatic(turn, text) {
 }
 function loadHistory(id, title) {
   closeMenus();
+  // Read-and-reset IMMEDIATELY: historyResumeInPlace must never outlive this one
+  // open→pick cycle. Past this line the module flag is back to its default, so any
+  // later, unrelated opening/pick of this same panel can't be affected by whichever
+  // entry point was used here.
+  const resumeInPlace = historyResumeInPlace;
+  historyResumeInPlace = false;
   // Already open in ANOTHER tab → don't open a second instance of the same
   // conversation; just switch to that tab. (Re-opening it in its OWN tab still
-  // reloads as before.)
+  // reloads as before.) Applies to BOTH entry points below — never worth a duplicate
+  // tab, in place or not.
   const already = tabs.find(tb => tb.sessionId === id && tb.id !== activeId);
   if (already) { switchTab(already.id); return; }
   let items = [];
   try { items = JSON.parse(window._loadSession(id) || '[]'); } catch (e) {}
-  // Opens the session in a NEW tab (matching the Claude Terminal view's Session
-  // History button, which always spawns a new tab too) rather than replacing
-  // whatever the current tab was doing — the old "replace the current tab" behavior
-  // (VSCode's own) silently discarded an in-progress conversation on that tab with
-  // no undo. createTab() makes the new tab active on its own (via switchTab()), so
-  // everything below this still operates on "the now-active tab" exactly as before.
+
+  // Two entry points, two behaviors (resumeInPlace, read above from historyResumeInPlace
+  // — set by whichever openHistory* function opened the panel, see window.openHistory*):
   //
-  // The old code's "if (t.streaming) doCancel(); hideWorking(); curTurn = null; …"
-  // is gone on purpose, not by oversight: those existed ONLY because the old design
-  // overwrote the PREVIOUSLY active tab's own pane/session in place, so an in-flight
-  // stream on that same tab had to be stopped before its output kept landing
-  // somewhere that no longer represented that conversation. Here the previously
-  // active tab is untouched — background tabs are allowed to keep streaming
-  // (loadRender's context-switch exists precisely so they don't block each other) —
-  // and t is a brand-new tab straight out of createTab(), which starts with no
-  // streaming, no render state, and its own fresh (empty) pane, so there is nothing
-  // on THIS tab that curTurn/curBody/etc. or doCancel() would ever need to clear.
-  const t = createTab({ sessionId: id, titled: true });
-  loadRender(t);                        // operate on THIS tab's render state
+  //  - Toolbar's Session History button → opens a NEW tab, matching the Claude
+  //    Terminal view's own History button (--resume is a launch flag, its only
+  //    option there). Avoids the old "replace the current tab" behavior's real cost:
+  //    it silently discarded an in-progress conversation on that tab, no undo.
+  //
+  //  - /resume typed in the composer → loads IN PLACE on the CURRENT tab, matching
+  //    the CLI's own /resume typed at an existing Claude Terminal prompt: it swaps
+  //    THAT session in place too, no new tab. /resume is something you type INTO a
+  //    specific conversation ("change what THIS is"), unlike the toolbar's generic
+  //    "browse history" with no such context — the two are allowed to differ.
+  let t;
+  if (resumeInPlace) {
+    t = activeTab(); if (!t) return;
+    loadRender(t);                        // operate on THIS tab's render state
+    // An in-flight stream on the tab being overwritten must stop NOW, or its output
+    // keeps landing in a pane that no longer represents that conversation — unlike
+    // the new-tab path, this tab is NOT untouched, its live content is about to be
+    // replaced out from under it.
+    if (t.streaming) doCancel();
+    hideWorking();
+    curTurn = null; curBody = null; curText = ''; curThink = null; curThinkText = '';
+  } else {
+    t = createTab({ sessionId: id, titled: true });
+    loadRender(t);                        // operate on THIS tab's render state
+    // t is brand new (no stream, no render state) — nothing here to cancel or clear.
+  }
   const pane = t.pane;
-  pane.innerHTML = '';                  // clear createTab()'s WELCOME_HTML placeholder
+  pane.innerHTML = '';                  // clear old content (or createTab()'s WELCOME_HTML)
+  t.sessionId = id;                     // continuing this tab resumes the session
   setTabTitle(t, title);
   if (!items.length) { addSystem('This conversation is empty or could not be loaded.'); }
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -213,15 +213,27 @@ function loadHistory(id, title) {
   if (already) { switchTab(already.id); return; }
   let items = [];
   try { items = JSON.parse(window._loadSession(id) || '[]'); } catch (e) {}
-  // Replace the CURRENT tab's content with the selected session (VSCode behaviour).
-  const t = activeTab(); if (!t) return;
+  // Opens the session in a NEW tab (matching the Claude Terminal view's Session
+  // History button, which always spawns a new tab too) rather than replacing
+  // whatever the current tab was doing — the old "replace the current tab" behavior
+  // (VSCode's own) silently discarded an in-progress conversation on that tab with
+  // no undo. createTab() makes the new tab active on its own (via switchTab()), so
+  // everything below this still operates on "the now-active tab" exactly as before.
+  //
+  // The old code's "if (t.streaming) doCancel(); hideWorking(); curTurn = null; …"
+  // is gone on purpose, not by oversight: those existed ONLY because the old design
+  // overwrote the PREVIOUSLY active tab's own pane/session in place, so an in-flight
+  // stream on that same tab had to be stopped before its output kept landing
+  // somewhere that no longer represented that conversation. Here the previously
+  // active tab is untouched — background tabs are allowed to keep streaming
+  // (loadRender's context-switch exists precisely so they don't block each other) —
+  // and t is a brand-new tab straight out of createTab(), which starts with no
+  // streaming, no render state, and its own fresh (empty) pane, so there is nothing
+  // on THIS tab that curTurn/curBody/etc. or doCancel() would ever need to clear.
+  const t = createTab({ sessionId: id, titled: true });
   loadRender(t);                        // operate on THIS tab's render state
-  if (t.streaming) doCancel();
-  hideWorking();
-  curTurn = null; curBody = null; curText = ''; curThink = null; curThinkText = '';
   const pane = t.pane;
-  pane.innerHTML = '';
-  t.sessionId = id;                                   // continuing this tab resumes the session
+  pane.innerHTML = '';                  // clear createTab()'s WELCOME_HTML placeholder
   setTabTitle(t, title);
   if (!items.length) { addSystem('This conversation is empty or could not be loaded.'); }
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -69,7 +69,19 @@ window.onHistoryLoaded = function(json) {
   histLoaded = true; setHistoryLoading(false); renderHistoryList();
   clampOpenMenu();   // the list may be a different width than "Loading…" — re-pin so it isn't cut off
 };
-function toggleHistory(anchor) {
+/* Called from the native Eclipse view toolbar's "Session history" Action
+ * (ClaudeGuiView#createToolBar → pushToolbarAction) — that button lives outside the
+ * webview entirely, so there's no in-page anchor element to glue the panel to the
+ * way an ordinary in-page button would (see positionMenuFixed's comment in ui.js).
+ *
+ * Toggles: clicking the toolbar button again closes the panel. This works cleanly
+ * here (unlike an in-page trigger) because the click never reaches the page's own
+ * document-level "close on click outside" listener at all — this function is the
+ * ENTIRE reaction to that click, so wasOpen faithfully reflects the panel's state
+ * from just before this call, with no risk of that other listener having already
+ * closed it first.
+ */
+window.openHistoryFromToolbar = function() {
   const panel = document.getElementById('history-panel');
   const wasOpen = panel.classList.contains('open');
   closeMenus();
@@ -81,10 +93,10 @@ function toggleHistory(anchor) {
   renderHistoryList();
   loadHistoryAsync();
   panel.classList.add('open');
-  positionMenu(panel, anchor);
-  openMenuEl = panel; openAnchor = anchor;
+  positionMenuFixed(panel);
+  openMenuEl = panel;   // openAnchor stays null — nothing in-page to re-anchor to
   if (s) setTimeout(() => s.focus(), 0);
-}
+};
 function histTab(which) {
   const local = which === 'local';
   document.getElementById('hist-tab-local').classList.toggle('active', local);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -297,20 +297,27 @@ function loadHistory(id, title) {
   //    Terminal view's own History button (--resume is a launch flag, its only
   //    option there). Avoids the old "replace the current tab" behavior's real cost:
   //    it silently discarded an in-progress conversation on that tab, no undo.
+  //    EXCEPTION: if the current tab is already empty (isTabEmpty — no session, no
+  //    stream, nothing typed or attached), there is nothing an "in-progress
+  //    conversation" cost could apply to, so reuse it instead of leaving a blank tab
+  //    behind — same reuse the resumeInPlace branch below does, just reached by a
+  //    different condition.
   //
   //  - /resume typed in the composer → loads IN PLACE on the CURRENT tab, matching
   //    the CLI's own /resume typed at an existing Claude Terminal prompt: it swaps
   //    THAT session in place too, no new tab. /resume is something you type INTO a
   //    specific conversation ("change what THIS is"), unlike the toolbar's generic
   //    "browse history" with no such context — the two are allowed to differ.
+  const reuseCurrent = resumeInPlace || isTabEmpty(activeTab());
   let t;
-  if (resumeInPlace) {
+  if (reuseCurrent) {
     t = activeTab(); if (!t) return;
     loadRender(t);                        // operate on THIS tab's render state
     // An in-flight stream on the tab being overwritten must stop NOW, or its output
     // keeps landing in a pane that no longer represents that conversation — unlike
     // the new-tab path, this tab is NOT untouched, its live content is about to be
-    // replaced out from under it.
+    // replaced out from under it. (No-op for the isTabEmpty case: that condition
+    // already excludes a streaming tab.)
     if (t.streaming) doCancel();
     hideWorking();
     curTurn = null; curBody = null; curText = ''; curThink = null; curThinkText = '';

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -96,7 +96,29 @@ function openHistoryPanel(resumeInPlace) {
   loadHistoryAsync();
   panel.classList.add('open');
   if (s) setTimeout(() => s.focus(), 0);
+  // Same mechanism the advisor card / rewind dialog / model picker / lightbox use:
+  // without this, the Java-side cancel-key context (Esc, or Ctrl+G under Emacs — see
+  // plugin.xml's dismissCard binding) never activates for this panel, because nothing
+  // on the Java side raised it. closeHistoryPanel is registered (not the generic
+  // closeMenus) so ui.js's closeMenus() can tell, via identity, whether ITS registration
+  // is still the live one before unregistering — a later overlay (e.g. an in-transcript
+  // image's lightbox) can register after this panel closed-then-reopened in the same
+  // event's bubble phase, and closeMenus() must not clobber that newer registration.
+  registerOverlayCancel(closeHistoryPanel, false);
   return true;
+}
+
+/* The ONE place that closes history-panel specifically — every other close path (click
+ * outside, opening a different menu, picking a session, the Java-bound cancel key) routes
+ * through here or through closeMenus() (ui.js), which defers to this when it detects the
+ * panel was open. Kept as its own function (not inlined into closeMenus) so that deferral
+ * can check identity: activeCardCancel === closeHistoryPanel is how closeMenus knows the
+ * registration it might unregister is still this panel's, not some other overlay's. */
+function closeHistoryPanel() {
+  const panel = document.getElementById('history-panel');
+  if (panel) panel.classList.remove('open');
+  if (openMenuEl === panel) { openMenuEl = null; openAnchor = null; }
+  unregisterOverlayCancel();
 }
 
 /* Called from the native Eclipse view toolbar's "Session history" Action

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -163,7 +163,7 @@ function startHistoryRename(itemEl, session) {
       titleEl.textContent = newTitle;
       if (window._renameSession) window._renameSession(session.sessionId, newTitle);
       const t = tabs.find(tab => tab.sessionId === session.sessionId);
-      if (t) { t.title = newTitle; if (t.id === activeId) document.getElementById('convo-title').textContent = newTitle; renderTabs(); }
+      if (t) { t.title = newTitle; renderTabs(); }
     }
   }
   inp.onblur = () => finish(true);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
@@ -93,12 +93,15 @@ function handleSlashCommand(text) {
   if (cmd === '/advisor') { openAdvisorCard(text); return true; }
   if (cmd === '/model') { handleModelCommand(text); return true; }
   if (cmd === '/rewind') { openRewindDialog(); return true; }      // deliberately unchanged
-  // Opens the SAME history panel the toolbar's Session History button does — the CLI's
-  // own /resume is an interactive picker (local-jsx) that only exists in its terminal
+  // Opens the SAME history panel the toolbar's Session History button does, but via
+  // openHistoryForResume (not openHistoryFromToolbar) — picking a session here loads
+  // it into the CURRENT tab in place, matching the CLI's own /resume typed at an
+  // existing Claude Terminal prompt (see history.js's historyResumeInPlace). The CLI's
+  // real /resume is an interactive picker (local-jsx) that only exists in its terminal
   // TUI; this headless process (-p --input-format stream-json) has no such thing to
   // send it to, same reason /model is reproduced locally above rather than forwarded.
   // No echo: nothing was actually sent, just a panel opened, like /rewind.
-  if (cmd === '/resume') { openHistoryFromToolbar(); return true; }
+  if (cmd === '/resume') { openHistoryForResume(); return true; }
   if (cmd === '/help') {
     const ht = activeTab();
     addUserMessage(text);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/slash.js
@@ -7,6 +7,7 @@ const SLASH_COMMANDS = [
   { cmd: '/clear',   desc: 'Start a new session (tab)' },
   { cmd: '/compact', desc: 'Clear conversation history but keep a summary in context' },
   { cmd: '/model',   desc: 'Switch model' },
+  { cmd: '/resume',  desc: 'Open session history' },
   { cmd: '/rewind',  desc: 'Restore code and fork from an earlier message' },
   { cmd: '/help',    desc: 'Show available commands' },
 ];
@@ -92,6 +93,12 @@ function handleSlashCommand(text) {
   if (cmd === '/advisor') { openAdvisorCard(text); return true; }
   if (cmd === '/model') { handleModelCommand(text); return true; }
   if (cmd === '/rewind') { openRewindDialog(); return true; }      // deliberately unchanged
+  // Opens the SAME history panel the toolbar's Session History button does — the CLI's
+  // own /resume is an interactive picker (local-jsx) that only exists in its terminal
+  // TUI; this headless process (-p --input-format stream-json) has no such thing to
+  // send it to, same reason /model is reproduced locally above rather than forwarded.
+  // No echo: nothing was actually sent, just a panel opened, like /rewind.
+  if (cmd === '/resume') { openHistoryFromToolbar(); return true; }
   if (cmd === '/help') {
     const ht = activeTab();
     addUserMessage(text);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -333,6 +333,24 @@ function startTitleEdit(tabId) {
 /* New conversation in the ACTIVE root — a new FOLDER is newRootDirectory(). */
 function newSession() { closeMenus(); createTab({ rootId: activeRootId }); input.focus(); }
 
+/* True when t has no conversation AND nothing typed/attached that a reuse would lose —
+ * checked before silently repurposing a tab instead of opening a new one (see
+ * loadHistory's toolbar branch in history.js). Active-tab only: reads the composer live
+ * from #input rather than t.draft, which is only synced on switchTab (see its own
+ * comment) and so can be stale for the tab currently on screen.
+ *
+ * t.sessionId === '' alone is NOT enough — /help echoes a user bubble + a system message
+ * without ever sending anything to the CLI (slash.js), and /clear echoes its own command
+ * bubble back into an emptied pane, so both leave a sessionId-less tab with real content
+ * on screen. addUserMessage()/addSystem() both append into t.pane, and createTab() seeds
+ * it with WELCOME_HTML's placeholder and nothing else — so the pane itself, not sessionId,
+ * is what actually answers "is there something here a reuse would silently discard". */
+function isTabEmpty(t) {
+  return !!t && t === activeTab() && !t.sessionId && !t.streaming && !t.pendingCard
+      && !(t.images && t.images.length) && !input.value.trim()
+      && !t.pane.querySelector('.turn');
+}
+
 /* /clear — start a fresh conversation IN PLACE. VSCode stays on the tab the
    command was invoked from rather than opening another one, so the tab, its
    position and its composer settings (model/effort/thinking/mode) all survive;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -27,6 +27,12 @@
  */
 /** @type {Tab[]} */
 let tabs = [], activeId = null, tabSeq = 0;
+// id of the tab currently mid-rename (double-clicked .tt), or null. renderTabs() runs
+// on every tab add/remove/reorder/retitle — including a BACKGROUND tab's stream
+// naming itself — so a bare rebuild would blow away whatever's typed into another
+// tab's input mid-edit. Tracked here so renderTabs() can re-create that one input
+// (with its value/selection preserved) instead of just losing it.
+let editingTabId = null;
 // Defaults a NEW conversation starts with (not inherited from the last-viewed tab).
 const DEFAULT_EFFORT_IDX = 2;      // "high"
 const DEFAULT_THINKING = false;    // thinking off
@@ -117,7 +123,6 @@ function switchTab(id) {
   const ar = activeRoot && activeRoot();
   if (ar) ar.activeTabId = id;
   if (t) {
-    document.getElementById('convo-title').textContent = t.title;
     applyTabSettings(t);   // restore this conversation's model/effort/thinking
     input.value = t.draft || '';                                    // restore this tab's draft
     input.style.height = 'auto';
@@ -224,16 +229,28 @@ function moveTab(fromId, toId, after) {
 }
 function renderTabs() {
   const c = document.getElementById('tabs'); if (!c) return;
+  // Snapshot the in-progress edit (if any) so the rebuild below can restore it —
+  // the input element itself is about to be destroyed along with the rest of #tabs.
+  let editSnapshot = null;
+  if (editingTabId) {
+    const liveInp = c.querySelector('.tab.editing .title-input');
+    if (liveInp) editSnapshot = { value: liveInp.value, selStart: liveInp.selectionStart, selEnd: liveInp.selectionEnd };
+  }
   c.innerHTML = '';
   // Only the active root's conversations. The array stays flat and globally ordered,
   // so a filtered view keeps each root's tabs in the order the user dragged them into.
   tabs.filter(t => t.rootId === activeRootId).forEach(t => {
-    const el = document.createElement('div'); el.className = 'tab' + (t.id === activeId ? ' active' : '');
-    el.draggable = true; el.dataset.id = t.id;
+    const editing = t.id === editingTabId;
+    const el = document.createElement('div'); el.className = 'tab' + (t.id === activeId ? ' active' : '') + (editing ? ' editing' : '');
+    el.draggable = !editing;   // a draggable ancestor steals mousedown-drag from an input's own text selection
+    el.dataset.id = t.id;
     el.innerHTML = '<span class="ti">' + ICONS.SUNBURST + '</span><span class="tt"></span><span class="tab-close">' + ICONS.X + '</span>';
-    el.querySelector('.tt').textContent = t.title;
+    const tt = el.querySelector('.tt');
     el.title = t.title;
-    el.onclick = (e) => { if (e.target.closest('.tab-close')) closeTab(t.id); else switchTab(t.id); };
+    el.onclick = (e) => { if (e.target.closest('.tab-close')) closeTab(t.id); else if (!editing) switchTab(t.id); };
+    tt.ondblclick = (e) => { e.stopPropagation(); startTitleEdit(t.id); };
+    if (editing) startTabEditInput(el, tt, t, editSnapshot);
+    else tt.textContent = t.title;
     // Drag-to-reorder with a drop-line indicator (best-practice: line before/after).
     el.addEventListener('dragstart', (e) => {
       dragTabId = t.id; el.classList.add('dragging');
@@ -275,54 +292,43 @@ function renderTabs() {
 function setTabTitle(t, raw) {
   const title = ((stripContext(raw) || raw || '').trim().slice(0, 40)) || 'Claude Code';
   t.title = title; t.titled = true;
-  if (t.id === activeId) document.getElementById('convo-title').textContent = title;
   renderTabs();
 }
-function startTitleEdit() {
-  const t = activeTab(); if (!t) return;
-  const wrap = document.getElementById('title-wrap'); if (!wrap) return;
-  // Already editing → clicking the input again does nothing (no re-open, no clone).
-  if (wrap.querySelector('.title-input')) return;
-  const titleEl = document.getElementById('convo-title');
-  const editBtn = document.getElementById('title-edit');
-  if (!titleEl || !editBtn) return;
-  const curTitle = t.title || 'Claude Code';
-  titleEl.style.display = 'none';
-  editBtn.style.display = 'none';
+/* Renders the <input> for the tab currently being renamed, called from renderTabs()
+ * both on first open (resume === null) and on every subsequent rebuild while the edit
+ * is still open (resume carries over the value/selection a rebuild would otherwise
+ * wipe — see editingTabId's comment). */
+function startTabEditInput(el, tt, t, resume) {
   const inp = document.createElement('input');
-  inp.type = 'text'; inp.className = 'title-input'; inp.value = curTitle;
-  wrap.appendChild(inp);
-  // Size the field to its content via a hidden mirror span (inputs don't shrink-wrap).
-  // border-box width = text width + the space the pencil used to take (gap+icon ≈ 19px),
-  // which (a) matches the hovered pill's width and (b) is the allowance that keeps the
-  // text from ever being clipped — the input's own padding/border overhead lives inside it.
-  const EDIT_ALLOWANCE = 20;
-  const meas = document.createElement('span');
-  meas.style.cssText = 'position:absolute;visibility:hidden;white-space:pre;font-size:13px;font-weight:600;';
-  document.body.appendChild(meas);
-  const sizer = () => { meas.textContent = inp.value || ' '; inp.style.width = Math.min(324, meas.offsetWidth + EDIT_ALLOWANCE) + 'px'; };
-  inp.oninput = sizer; sizer();
-  inp.focus(); inp.select();
+  inp.type = 'text'; inp.className = 'title-input'; inp.value = resume ? resume.value : (t.title || 'Claude Code');
+  tt.replaceWith(inp);
+  inp.focus();
+  if (resume) inp.setSelectionRange(resume.selStart, resume.selEnd);
+  else inp.select();
   let done = false;
   function finish(save) {
     if (done) return; done = true;
     const newTitle = inp.value.trim() || 'Claude Code';
-    inp.remove(); meas.remove();
-    titleEl.style.display = '';
-    editBtn.style.display = '';
-    if (save && newTitle !== curTitle) {
+    editingTabId = null;
+    if (save && newTitle !== t.title) {
       t.title = newTitle; t.titled = true;
-      titleEl.textContent = newTitle;
-      renderTabs();
       if (t.sessionId && window._renameSession) window._renameSession(t.sessionId, newTitle);
     }
+    renderTabs();
   }
-  inp.onclick = (e) => e.stopPropagation();   // don't bubble to the wrap's onclick
+  inp.onclick = (e) => e.stopPropagation();   // don't bubble to the tab's onclick (switchTab)
   inp.onblur = () => finish(true);
   inp.onkeydown = (e) => {
+    e.stopPropagation();   // don't let Enter/Escape reach anything else while renaming
     if (e.key === 'Enter') { e.preventDefault(); finish(true); }
     else if (e.key === 'Escape') { e.preventDefault(); inp.onblur = null; finish(false); }
   };
+}
+function startTitleEdit(tabId) {
+  const t = tabById(tabId); if (!t) return;
+  if (editingTabId === tabId) return;   // already editing this tab → no-op
+  editingTabId = tabId;
+  renderTabs();
 }
 /* New conversation in the ACTIVE root — a new FOLDER is newRootDirectory(). */
 function newSession() { closeMenus(); createTab({ rootId: activeRootId }); input.focus(); }
@@ -359,7 +365,6 @@ function clearSession() {
   t.followTail = true; t.scrollTop = 0;
   followTail = true;
   if (typeof updateJumpToLatest === 'function') updateJumpToLatest();
-  document.getElementById('convo-title').textContent = t.title;
   renderTabs();
   if (typeof renderPendingImages === 'function') renderPendingImages();
   if (typeof syncComposer === 'function') syncComposer();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -36,6 +36,32 @@ function toggleMenu(id, anchor) {
   openMenuEl = menu; openAnchor = anchor;
 }
 
+/* Drops a menu from the page's top-right corner rather than gluing it to an in-page
+   button — for a trigger that lives OUTSIDE the webview entirely (a native Eclipse
+   toolbar Action has no DOM element of its own to hand positionMenu/getBoundingClientRect).
+   The Eclipse view toolbar sits directly above the browser viewport with its actions
+   right-aligned, so this corner is the closest approximation to "under those buttons"
+   available without Java pushing the toolbar's actual screen coordinates across the
+   bridge — not true anchoring, just a fixed spot that reads as coming from up there.
+   No openAnchor is set (there's nothing to re-anchor to): clampOpenMenu's anchorless
+   branch already keeps a fixed-position menu on-screen through a resize on its own. */
+function positionMenuFixed(menu, rightGap) {
+  if (!menu) return;
+  const mw = menu.offsetWidth;
+  const left = Math.max(8, window.innerWidth - mw - (rightGap != null ? rightGap : 8));
+  // Below whichever header row is actually the last one visible — #update-banner
+  // sits right after #convo-header in the DOM and shows only when the installed CLI
+  // is outdated, so anchoring to #convo-header alone would put the panel under the
+  // banner instead of below it on those days. Read live, not hardcoded, so a taller
+  // header (a longer title) or the banner appearing/disappearing still clears
+  // correctly. +6 gap matches positionMenu's own below-anchor case.
+  const banner = document.getElementById('update-banner');
+  const bannerShown = banner && banner.classList.contains('show');
+  const header = document.getElementById(bannerShown ? 'update-banner' : 'convo-header');
+  const top = header ? header.getBoundingClientRect().bottom + 6 : 8;
+  menu.style.left = left + 'px'; menu.style.top = top + 'px';
+}
+
 // Disable the browser right-click context menu (no "Inspect element" in the plugin).
 document.addEventListener('contextmenu', (e) => e.preventDefault());
 
@@ -63,8 +89,11 @@ document.addEventListener('click', openLinkExternally, true);
 document.addEventListener('auxclick', (e) => { if (e.button === 1) openLinkExternally(e); }, true);
 
 document.addEventListener('click', (e) => {
+  // #history-btn is gone (moved to the native toolbar, see openHistoryFromToolbar in
+  // history.js) — its trigger is now outside the page entirely, so there's no in-page
+  // button click for this listener to exempt; nothing else changes here.
   if (openMenuEl && !openMenuEl.contains(e.target) &&
-      !e.target.closest('#plus-btn,#slash-btn,#modes-btn,#history-btn')) closeMenus();
+      !e.target.closest('#plus-btn,#slash-btn,#modes-btn')) closeMenus();
   // The slash menu isn't tracked by openMenuEl — close it on any click outside it,
   // the input, or the slash button.
   if (slashState.open && !e.target.closest('#slash-menu,#input,#slash-btn')) closeSlash();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -103,6 +103,26 @@ document.addEventListener('click', (e) => {
   if (slashState.open && !e.target.closest('#slash-menu,#input,#slash-btn')) closeSlash();
 });
 
+// Escape closes whichever .menu is open (history panel, modes/actions/plus menus, …) —
+// these only had click-outside to dismiss them before, unlike every CARD/dialog in the
+// app (cards.js, advisor.js, rewind.js, models.js, images.js, tabs.js), which each
+// already handle Escape themselves via their own document-level capture-phase listener.
+// No target/field check needed: none of the inputs living inside these menus (e.g.
+// #hist-search) have their own Escape handling to preserve, so closing the menu out
+// from under a focused search box is exactly the wanted behavior, not a conflict.
+//
+// Bails when activeCardCancel (carddock.js) is set — a card/overlay is up. This is
+// NOT just about listener ordering: e.preventDefault() (what every card's own Escape
+// handler calls) does not stop propagation or other listeners, only stopPropagation
+// does, and no card ever calls that. So without this check, Escape meant to dismiss a
+// card that happened to appear while a menu was ALSO left open (the two systems don't
+// coordinate — a background tab's approval card can appear at any time, regardless of
+// what the foreground tab has open) would incorrectly close the menu too, alongside
+// whatever the card's own handler does.
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && openMenuEl && !activeCardCancel) { e.preventDefault(); closeMenus(); }
+});
+
 // Re-pin the open menu/panel so it stays on-screen — snaps its right edge near the
 // viewport edge, only sliding left (and letting the far side clip) once the viewport
 // is narrower than the menu itself. Used on resize AND after async content changes

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -3,11 +3,26 @@
 
 /* ---- front-end-only interactions ---- */
 let openMenuEl = null, openAnchor = null;   // openAnchor = the trigger element the menu is glued to
-function closeMenus() { document.querySelectorAll('.menu.open').forEach(m => m.classList.remove('open'));
+function closeMenus() {
+  // history-panel is the one .menu that also needs the Java-side cancel-key context
+  // (see registerOverlayCancel in history.js) — every OTHER close path for it funnels
+  // through here (click-outside, opening a different menu, …), so this is the one
+  // place that can defer to closeHistoryPanel's own unregister when it was open.
+  //
+  // Guarded by identity, not just "was it open": activeCardCancel is ONE global slot,
+  // and a later overlay (e.g. an in-transcript image's lightbox, registered during the
+  // click's target phase) can install ITS OWN cancel before this listener runs in the
+  // bubble phase — unregistering unconditionally here would wipe that newer
+  // registration and tell Java the wrong overlay just closed.
+  const hist = document.getElementById('history-panel');
+  const histWasOpen = hist && hist.classList.contains('open');
+  document.querySelectorAll('.menu.open').forEach(m => m.classList.remove('open'));
   document.querySelectorAll('.tbtn.active-tmp').forEach(b=>b.classList.remove('active-tmp'));
   // per-message badges are pinned visible while their menu is up — unpin them
   document.querySelectorAll('.msg-actions.open').forEach(w => w.classList.remove('open'));
-  openMenuEl = null; openAnchor = null; }
+  openMenuEl = null; openAnchor = null;
+  if (histWasOpen && activeCardCancel === closeHistoryPanel) unregisterOverlayCancel();
+}
 
 /* Position a menu relative to its trigger button, so it stays glued to that element
    (in X and Y) when the view is resized — its reference is the element behind it.

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -50,14 +50,16 @@ function positionMenuFixed(menu, rightGap) {
   const mw = menu.offsetWidth;
   const left = Math.max(8, window.innerWidth - mw - (rightGap != null ? rightGap : 8));
   // Below whichever header row is actually the last one visible — #update-banner
-  // sits right after #convo-header in the DOM and shows only when the installed CLI
-  // is outdated, so anchoring to #convo-header alone would put the panel under the
-  // banner instead of below it on those days. Read live, not hardcoded, so a taller
-  // header (a longer title) or the banner appearing/disappearing still clears
-  // correctly. +6 gap matches positionMenu's own below-anchor case.
+  // sits right after #toolbar in the DOM and shows only when the installed CLI is
+  // outdated, so anchoring to #toolbar alone would put the panel under the banner
+  // instead of below it on those days. Read live, not hardcoded, so the banner
+  // appearing/disappearing still clears correctly. +6 gap matches positionMenu's
+  // own below-anchor case. (#convo-header is gone — titles are edited in place on
+  // each tab now, see tabs.js's startTitleEdit — so #toolbar is the last header-ish
+  // row left when the banner is hidden.)
   const banner = document.getElementById('update-banner');
   const bannerShown = banner && banner.classList.contains('show');
-  const header = document.getElementById(bannerShown ? 'update-banner' : 'convo-header');
+  const header = document.getElementById(bannerShown ? 'update-banner' : 'toolbar');
   const top = header ? header.getBoundingClientRect().bottom + 6 : 8;
   menu.style.left = left + 'px'; menu.style.top = top + 'px';
 }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -40,27 +40,29 @@ function toggleMenu(id, anchor) {
    button — for a trigger that lives OUTSIDE the webview entirely (a native Eclipse
    toolbar Action has no DOM element of its own to hand positionMenu/getBoundingClientRect).
    The Eclipse view toolbar sits directly above the browser viewport with its actions
-   right-aligned, so this corner is the closest approximation to "under those buttons"
-   available without Java pushing the toolbar's actual screen coordinates across the
-   bridge — not true anchoring, just a fixed spot that reads as coming from up there.
+   right-aligned, so pinning to the page's own top edge (see the `top` calculation
+   below) is the closest approximation to "under those buttons" available without Java
+   pushing the toolbar's actual screen coordinates across the bridge — not true
+   anchoring, just a fixed spot that reads as coming from up there.
    No openAnchor is set (there's nothing to re-anchor to): clampOpenMenu's anchorless
    branch already keeps a fixed-position menu on-screen through a resize on its own. */
 function positionMenuFixed(menu, rightGap) {
   if (!menu) return;
   const mw = menu.offsetWidth;
   const left = Math.max(8, window.innerWidth - mw - (rightGap != null ? rightGap : 8));
-  // Below whichever header row is actually the last one visible — #update-banner
-  // sits right after #toolbar in the DOM and shows only when the installed CLI is
-  // outdated, so anchoring to #toolbar alone would put the panel under the banner
-  // instead of below it on those days. Read live, not hardcoded, so the banner
-  // appearing/disappearing still clears correctly. +6 gap matches positionMenu's
-  // own below-anchor case. (#convo-header is gone — titles are edited in place on
-  // each tab now, see tabs.js's startTitleEdit — so #toolbar is the last header-ish
-  // row left when the banner is hidden.)
+  // The native toolbar button that opens this (Eclipse view toolbar's "Session
+  // history") sits directly above the webview, at the SAME screen level as #toolbar
+  // (the tab strip) — not above it. So the panel drops from #toolbar's TOP edge,
+  // reading as "right below the button", rather than clearing the tab strip's own
+  // 35px height first. #update-banner sits below #toolbar and only shows when the
+  // installed CLI is outdated; on those days the panel would otherwise land on top
+  // of it, so it takes over as the anchor while shown. Read live, not hardcoded, so
+  // the banner appearing/disappearing still clears correctly.
   const banner = document.getElementById('update-banner');
   const bannerShown = banner && banner.classList.contains('show');
-  const header = document.getElementById(bannerShown ? 'update-banner' : 'toolbar');
-  const top = header ? header.getBoundingClientRect().bottom + 6 : 8;
+  const toolbar = document.getElementById('toolbar');
+  const top = bannerShown ? banner.getBoundingClientRect().bottom + 6
+    : (toolbar ? toolbar.getBoundingClientRect().top : 8);
   menu.style.left = left + 'px'; menu.style.top = top + 'px';
 }
 

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
@@ -110,7 +110,9 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 #cwd-row .ct { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
 /* ── Conversation header ─────────────────────────────────── */
-#convo-header { display: flex; align-items: center; justify-content: space-between;
+/* Only child now (New Session / Session history moved to the native toolbar) —
+   no justify-content needed to keep the title pinned to the left edge. */
+#convo-header { display: flex; align-items: center;
   padding: 9px 14px; flex-shrink: 0; border-bottom: 1px solid var(--border); }
 
 /* ---- CLI update banner ----
@@ -143,7 +145,6 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 #convo-header .title-input { max-width: 340px; box-sizing: border-box;
   background: var(--bg-code); border: 1px solid var(--accent); border-radius: 5px;
   padding: 3px 6px; color: var(--fg); font-size: 13px; font-weight: 600; outline: none; }
-#convo-header .actions { display: flex; gap: 2px; }
 
 
 /* ── Composer ────────────────────────────────────────────── */

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/layout.css
@@ -51,6 +51,14 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
   color: var(--fg-dim); cursor: pointer; border-radius: 3px; flex-shrink: 0; visibility: hidden; }
 .tab.active .tab-close, .tab:hover .tab-close { visibility: visible; }
 .tab .tab-close:hover, .stab .stab-close:hover { background: var(--bg-hover); color: var(--fg); }
+/* Double-click a tab's title (tabs.js: startTitleEdit) to rename in place — this
+   replaces the old separate #convo-header row entirely. Widened past the normal
+   200px cap so a rename isn't typed through a keyhole; #tabs already scrolls
+   horizontally, so one wider tab during an edit doesn't crowd the others out. */
+.tab.editing { max-width: 340px; }
+.tab .title-input { width: 100%; height: 20px; box-sizing: border-box;
+  background: var(--bg-code); border: 1px solid var(--accent); border-radius: 4px;
+  padding: 0 4px; color: var(--fg); font-size: 12.5px; font-weight: inherit; outline: none; }
 .pane > .turn:first-child { margin-top: 0; }
 #toolbar .spacer { flex: 1; }
 #toolbar .tools { display: flex; align-items: center; gap: 2px; padding-right: 8px; }
@@ -109,12 +117,6 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 #cwd-row .ci { display: inline-flex; flex-shrink: 0; color: var(--accent); }
 #cwd-row .ct { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
-/* ── Conversation header ─────────────────────────────────── */
-/* Only child now (New Session / Session history moved to the native toolbar) —
-   no justify-content needed to keep the title pinned to the left edge. */
-#convo-header { display: flex; align-items: center;
-  padding: 9px 14px; flex-shrink: 0; border-bottom: 1px solid var(--border); }
-
 /* ---- CLI update banner ----
    Shown only when the installed Claude Code is behind the published release, so
    the model chooser (built from the ACCOUNT's models) can't silently offer models
@@ -132,20 +134,6 @@ html, body { height: 100%; background: var(--bg); color: var(--fg);
 #update-banner .ub-x { flex-shrink: 0; cursor: pointer; color: var(--warn-fg); opacity: .7;
   display: inline-flex; border-radius: 3px; }
 #update-banner .ub-x:hover { opacity: 1; background: var(--bg-hover); }
-/* The pill (.title-wrap) is the outer container at a fixed 32px height. The input sits
-   INSIDE it at its own smaller natural size, so the pill encompasses the input. Only the
-   pill's height is set here — the input is never forced to the pill's height. */
-#convo-header .title-wrap { display: flex; align-items: center; gap: 4px; min-width: 0; max-width: 340px;
-  height: 32px; box-sizing: border-box; padding: 0 6px; border-radius: 8px; margin: -1px -6px; cursor: pointer; }
-#convo-header .title-wrap:hover { background: var(--bg-hover); }
-#convo-header .title { font-weight: 600; font-size: 13px; color: var(--fg); overflow: hidden;
-  text-overflow: ellipsis; white-space: nowrap; }
-#convo-header .title-edit { color: var(--fg-faint); display: none; flex-shrink: 0; }
-#convo-header .title-wrap:hover .title-edit { display: inline-flex; }
-#convo-header .title-input { max-width: 340px; box-sizing: border-box;
-  background: var(--bg-code); border: 1px solid var(--accent); border-radius: 5px;
-  padding: 3px 6px; color: var(--fg); font-size: 13px; font-weight: 600; outline: none; }
-
 
 /* ── Composer ────────────────────────────────────────────── */
 /* position: relative so #jump-to-latest (chat.css) can anchor to this element's

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -29,6 +29,10 @@ public final class Constants {
     /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */
     public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
 
+    /** Set once the one-time "this sends /rename to the prompt" tooltip has been shown for
+     *  double-click tab renaming in the Claude Terminal view (per-workspace). */
+    public static final String PREF_CLI_RENAME_HINT_SHOWN = "cliRenameHintShown";
+
     public static final String PREF_HTTP_PROXY = "httpProxy";
     public static final String PREF_HTTPS_PROXY = "httpsProxy";
     public static final String PREF_NO_PROXY = "noProxy";

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -38,10 +38,17 @@ import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabFolder2Adapter;
 import org.eclipse.swt.custom.CTabFolderEvent;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.events.FocusListener;
+import org.eclipse.swt.events.KeyListener;
+import org.eclipse.swt.events.MouseAdapter;
+import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.FontData;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -49,8 +56,11 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
+import org.eclipse.swt.widgets.ToolTip;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.IShowInTarget;
@@ -198,6 +208,25 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             }
         }));
 
+        // Double-click a tab's title to rename its session via /rename — mirrors the Claude
+        // Code (GUI) view's own double-click-to-rename on its tab strip. Unlike the GUI
+        // view, there is no out-of-band control channel here: renaming actually pastes
+        // "/rename <title>" into the terminal's own prompt and submits it (see
+        // TerminalSession#sendCommand), same as if the user had typed it. The visible tab
+        // label updates on its own afterward via the EXISTING setTerminalTitle callback
+        // below (the CLI already pushes its title, /rename included, over the terminal's
+        // OSC title sequence) — nothing here sets the tab text directly.
+        tabFolder.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseDoubleClick(MouseEvent e) {
+                CTabItem item = tabFolder.getItem(new Point(e.x, e.y));
+                if (item == null) return;
+                TerminalSession session = (TerminalSession) item.getData();
+                if (session == null) return;
+                openRenameEditor(item, session);
+            }
+        });
+
         fontChangeListener = event -> {
             if (FONT_ID.equals(event.getProperty())) {
                 display.asyncExec(() -> {
@@ -335,6 +364,142 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         if (n == 1) return items.get(0);
         if (n == 2) return items.get(0) + " or " + items.get(1);
         return String.join(", ", items.subList(0, n - 1)) + ", or " + items.get(n - 1);
+    }
+
+    /**
+     * Opens an in-place editor over {@code item}'s label (double-click target) so the user
+     * can type a new title without leaving the tab strip. On Enter with non-blank text,
+     * sends {@code /rename <title>} to {@code session}'s own prompt and submits it — see
+     * {@link TerminalSession#sendCommand}. The visible tab label is NOT set here; it
+     * updates on its own once the CLI's OSC title update round-trips through the existing
+     * {@code setTerminalTitle} callback, same as any other terminal title change.
+     *
+     * <p>CTabFolder lays out its children as tab CONTENT below the strip, clipped to that
+     * area — a Text parented to the folder (or the view's own container) would be clipped
+     * or have its bounds overwritten by the next layout pass. Instead this uses a borderless,
+     * always-on-top Shell positioned over the tab's own screen bounds, exactly the standard
+     * SWT pattern for editing something a widget doesn't natively support inline. Rather than
+     * tracking the tab folder through scrolling/resizing, the editor just disposes itself on
+     * any event that would invalidate its position (folder resize, tab scroll, selection
+     * change, or losing focus) — it reappears on the next double-click, which is simpler and
+     * safer than re-anchoring a live overlay.
+     */
+    /** The tab-title glyphs the CLI itself pushes over the terminal's OSC title sequence
+     *  while a turn is in flight (REPL.tsx's TITLE_ANIMATION_FRAMES) or idle
+     *  (TITLE_STATIC_PREFIX), each followed by a space before the actual title. */
+    private static final String[] CLI_TITLE_PREFIXES = {"⠂ ", "⠐ ", "✳ "};
+
+    /** Strips what the CLI itself may have decorated the live tab text with, so the rename
+     *  editor seeds from the actual session title rather than round-tripping a stray prefix
+     *  or the terminated-tab suffix back into a NEW /rename command — e.g. without this, a
+     *  user who double-clicks and hits Enter without editing anything would rename the
+     *  session to "✳ my-session" or "my-session (terminated)" instead of leaving it alone. */
+    private static String sanitizeTabTitleForEdit(String tabText) {
+        String s = tabText;
+        if (s.endsWith(TERMINATED_TAB_SUFFIX)) {
+            s = s.substring(0, s.length() - TERMINATED_TAB_SUFFIX.length());
+        }
+        for (String prefix : CLI_TITLE_PREFIXES) {
+            if (s.startsWith(prefix)) { s = s.substring(prefix.length()); break; }
+        }
+        return s;
+    }
+
+    private void openRenameEditor(CTabItem item, TerminalSession session) {
+        // A terminated (but not yet disposed) session's PTY is dead — sendCommand's paste
+        // would "succeed" (the control isn't disposed) into a process that can never act on
+        // it, so the rename silently does nothing. Simplest to just not offer it.
+        if (session.disposed || session.terminatedShown) return;
+
+        Rectangle bounds = item.getBounds();
+        // Empty when the item is scrolled out of view (CTabFolder returns a zero rect rather
+        // than null) — nowhere sane to draw the editor, so just don't.
+        if (bounds.isEmpty()) return;
+
+        Shell editorShell = new Shell(getSite().getShell(), SWT.NO_TRIM | SWT.ON_TOP);
+        editorShell.setLayout(new FillLayout());
+        Text editor = new Text(editorShell, SWT.BORDER);
+        editor.setFont(item.getFont() != null ? item.getFont() : tabFolder.getFont());
+        editor.setText(sanitizeTabTitleForEdit(item.getText()));
+
+        Point topLeft = tabFolder.toDisplay(bounds.x, bounds.y);
+        editorShell.setBounds(topLeft.x, topLeft.y, bounds.width, bounds.height);
+
+        // Registered on tabFolder itself (not the short-lived editorShell), so they MUST be
+        // removed explicitly when the editor closes — otherwise every rename leaves a dead
+        // listener behind, growing unbounded over the life of the view. Declared via a
+        // one-element holder so the teardown closure below can reference (and remove) the
+        // exact listener instances created after it, in the single place both need them.
+        final Listener[] resizeListener = new Listener[1];
+        final SelectionListener[] selectionListener = new SelectionListener[1];
+        final boolean[] closed = {false};
+        // Tears the editor down exactly once, however it ends (Enter, Escape, focus loss,
+        // or the tab strip changing under it) — callers decide separately whether to also
+        // send the rename command, always AFTER this has run.
+        Runnable close = () -> {
+            if (closed[0]) return; closed[0] = true;
+            tabFolder.removeListener(SWT.Resize, resizeListener[0]);
+            tabFolder.removeSelectionListener(selectionListener[0]);
+            if (!editorShell.isDisposed()) editorShell.dispose();
+        };
+        editor.addKeyListener(KeyListener.keyPressedAdapter(e -> {
+            if (e.keyCode == SWT.CR || e.keyCode == SWT.KEYPAD_CR) {
+                String title = editor.getText().trim();
+                close.run();
+                if (title.isEmpty()) return;   // empty → cancel, NOT a bare "/rename " (that
+                                                // asks the CLI to invent a name instead)
+                session.sendCommand("/rename " + title);
+            } else if (e.keyCode == SWT.ESC) {
+                close.run();
+            }
+        }));
+        // Losing focus (click elsewhere, Alt-Tab, …) cancels rather than commits — matches
+        // Escape, not Enter: an accidental focus loss mid-edit shouldn't fire a rename the
+        // user never confirmed.
+        editor.addFocusListener(FocusListener.focusLostAdapter(e -> close.run()));
+        // Any of these invalidate the editor's screen position — see the method doc.
+        resizeListener[0] = e -> close.run();
+        selectionListener[0] = SelectionListener.widgetSelectedAdapter(e -> close.run());
+        tabFolder.addListener(SWT.Resize, resizeListener[0]);
+        tabFolder.addSelectionListener(selectionListener[0]);
+
+        editorShell.open();
+        editor.selectAll();
+        editor.setFocus();
+        // GTK can realize a brand-new Shell's window-manager focus grab a beat after this
+        // call returns (a window-level race distinct from ordinary same-shell widget focus
+        // moves, which are synchronous) — reassert once more after the current dispatch so
+        // the editor doesn't lose focus to whatever the tab click focused a moment earlier.
+        editorShell.getDisplay().asyncExec(() -> {
+            if (!editor.isDisposed()) editor.setFocus();
+        });
+
+        showRenameHintOnce(editorShell.getBounds());
+    }
+
+    /** Shows the one-time "this sends /rename to the prompt" tooltip just under a just-opened
+     *  rename editor's screen position — see {@link Constants#PREF_CLI_RENAME_HINT_SHOWN}.
+     *  Parented to the VIEW's own shell, not the short-lived editor shell: the editor is
+     *  disposed as soon as the user presses Enter (often within the tooltip's own display
+     *  window on a fast first rename), and a ToolTip is a child Widget of its parent Shell —
+     *  parenting it to the editor would cascade-dispose the tooltip right along with it,
+     *  which is exactly the one time this hint (skipping idle detection entirely) most needs
+     *  to actually be seen. Auto-dismisses like any native tooltip; never shown again after
+     *  this either way. */
+    private void showRenameHintOnce(Rectangle editorBounds) {
+        IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
+        if (prefs.getBoolean(Constants.PREF_CLI_RENAME_HINT_SHOWN)) return;
+        prefs.setValue(Constants.PREF_CLI_RENAME_HINT_SHOWN, true);
+
+        ToolTip tip = new ToolTip(getSite().getShell(), SWT.BALLOON | SWT.ICON_INFORMATION);
+        tip.setText("Renaming");
+        tip.setMessage("Sends \"/rename <title>\" to the prompt below — works best when "
+                + "Claude is idle and the prompt is empty.");
+        tip.setAutoHide(true);
+        // ToolTip doesn't self-position — anchor it just under where the editor appeared
+        // rather than defaulting to (0,0).
+        tip.setLocation(editorBounds.x, editorBounds.y + editorBounds.height);
+        tip.setVisible(true);
     }
 
     private void configureActionBars() {
@@ -801,6 +966,19 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             if (disposed || termControl == null || termControl.isDisposed()) return false;
             termControl.pasteString(text);
             focus();
+            return true;
+        }
+
+        /** Like {@link #sendText}, but also submits it with a real Enter (bare CR) — unlike
+         *  a plain paste, which deliberately lands at the prompt for the user to review/edit/
+         *  send themselves (see sendTextToActiveSession's callers). Used for double-click tab
+         *  rename ({@link #renameFromTabDoubleClick}), where the whole point is a fire-and-
+         *  forget slash command, not something left sitting in the prompt. Whatever else was
+         *  at the prompt when this runs gets submitted right along with it — same as a user
+         *  manually pasting a slash command over unrelated text, not a new risk this adds. */
+        boolean sendCommand(String text) {
+            if (!sendText(text)) return false;
+            termControl.sendKey('\r');
             return true;
         }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -655,6 +655,32 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
      */
     private void createToolBar() {
         IToolBarManager toolBar = getViewSite().getActionBars().getToolBarManager();
+
+        // Same two actions, same icons, as the Claude Terminal's own toolbar (see
+        // ClaudeCliView#configureActionBars) — moved out of the webview's own
+        // #convo-header row for visual consistency between the two views. Unlike the
+        // Terminal's (which spawn/resume a whole new CLI process directly), these call
+        // back into the page: the GUI's "new session" and "history" are page-level UI
+        // concepts (a new tab, an in-page searchable panel), not new OS processes.
+        Action newSession = new Action("New Session") {
+            @Override
+            public void run() { pushToolbarAction("newSession"); }
+        };
+        newSession.setToolTipText("New Claude Session");
+        newSession.setImageDescriptor(Activator.getImageDescriptor(
+                com.anthropic.claudecode.eclipse.Constants.IMG_NEW_CLI_SESSION));
+        toolBar.add(newSession);
+
+        Action sessionHistory = new Action("Session history") {
+            @Override
+            public void run() { pushToolbarAction("openHistoryFromToolbar"); }
+        };
+        sessionHistory.setToolTipText("Session history");
+        sessionHistory.setImageDescriptor(Activator.getImageDescriptor(
+                com.anthropic.claudecode.eclipse.Constants.IMG_SESSION_HISTORY));
+        toolBar.add(sessionHistory);
+        toolBar.add(new org.eclipse.jface.action.Separator());
+
         scrollLockAction = new Action("Scroll Lock", Action.AS_CHECK_BOX) {
             @Override
             public void run() { pushScrollLock(); }
@@ -663,6 +689,14 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         scrollLockAction.setImageDescriptor(Activator.getImageDescriptor(
                 com.anthropic.claudecode.eclipse.Constants.IMG_SCROLL_LOCK));
         toolBar.add(scrollLockAction);
+    }
+
+    /** Runs a no-argument page-side function by name, e.g. from a toolbar Action's
+     *  run() — the action lives outside the webview, so it has no DOM element of its
+     *  own to drive the call from the page side the way an in-page button would. */
+    private void pushToolbarAction(String jsFunctionName) {
+        if (browser == null || browser.isDisposed() || !pageLoaded) return;
+        browser.execute("window." + jsFunctionName + " && window." + jsFunctionName + "()");
     }
 
     /**

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -22,6 +22,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_TERMINAL_POSITION, "bottom");
         store.setDefault(Constants.PREF_DEBUG_MODE, false);
         store.setDefault(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, false);
+        store.setDefault(Constants.PREF_CLI_RENAME_HINT_SHOWN, false);
 
         store.setDefault(Constants.PREF_HTTP_PROXY, "");
         store.setDefault(Constants.PREF_HTTPS_PROXY, "");


### PR DESCRIPTION
Moves the panel's own New Session and Session History buttons into Eclipse's native view toolbar, replacing a separate title row with an editable tab title. 

Brings the panel's chrome in line with how Terminal looks and how Eclipse views normally present their actions, and frees up a row of vertical space.

- In both Terminal and Code, a conversation is now renamed by double-clicking its tab.
- If the current conversation is not empty, Session History opens a new tab instead of replacing the current one's conversation; One can still replace a non-empty conversation in place by typing `/resume`
- The History panel closes without taking any action by pressing Escape emulating behavior of native popups