### PR TITLE
Search conversation content in History, not just titles

### DIFF
--- a/claude-eclipse-core/src/lib.rs
+++ b/claude-eclipse-core/src/lib.rs
@@ -774,6 +774,34 @@ pub extern "system" fn Java_com_anthropic_claudecode_eclipse_NativeCore_sessionL
 }
 
 #[no_mangle]
+pub extern "system" fn Java_com_anthropic_claudecode_eclipse_NativeCore_sessionSearchContent(
+    mut env: JNIEnv,
+    _class: JClass,
+    workspace_root: JString,
+    session_ids_json: JString,
+    query: JString,
+) -> jstring {
+    let root: String = if workspace_root.is_null() {
+        String::new()
+    } else {
+        env.get_string(&workspace_root).ok().map(|s| s.into()).unwrap_or_default()
+    };
+    let ids_json: String = if session_ids_json.is_null() {
+        "[]".to_string()
+    } else {
+        env.get_string(&session_ids_json).ok().map(|s| s.into()).unwrap_or_else(|| "[]".to_string())
+    };
+    let q: String = if query.is_null() {
+        String::new()
+    } else {
+        env.get_string(&query).ok().map(|s| s.into()).unwrap_or_default()
+    };
+    let ids: Vec<String> = serde_json::from_str(&ids_json).unwrap_or_default();
+    let json = session::search_session_content(&root, &ids, &q);
+    env.new_string(json).unwrap_or_else(|_| env.new_string("[]").unwrap()).into_raw()
+}
+
+#[no_mangle]
 pub extern "system" fn Java_com_anthropic_claudecode_eclipse_NativeCore_sessionLoad(
     mut env: JNIEnv,
     _class: JClass,

--- a/claude-eclipse-core/src/lib.rs
+++ b/claude-eclipse-core/src/lib.rs
@@ -780,6 +780,8 @@ pub extern "system" fn Java_com_anthropic_claudecode_eclipse_NativeCore_sessionS
     workspace_root: JString,
     session_ids_json: JString,
     query: JString,
+    own_messages_only: jboolean,
+    generation: jlong,
 ) -> jstring {
     let root: String = if workspace_root.is_null() {
         String::new()
@@ -797,7 +799,7 @@ pub extern "system" fn Java_com_anthropic_claudecode_eclipse_NativeCore_sessionS
         env.get_string(&query).ok().map(|s| s.into()).unwrap_or_default()
     };
     let ids: Vec<String> = serde_json::from_str(&ids_json).unwrap_or_default();
-    let json = session::search_session_content(&root, &ids, &q);
+    let json = session::search_session_content(&root, &ids, &q, own_messages_only != 0, generation as u64);
     env.new_string(json).unwrap_or_else(|_| env.new_string("[]").unwrap()).into_raw()
 }
 

--- a/claude-eclipse-core/src/session.rs
+++ b/claude-eclipse-core/src/session.rs
@@ -347,7 +347,15 @@ static SEARCH_GENERATION: AtomicU64 = AtomicU64::new(0);
 ///   messages), skipping assistant turns entirely — a cheaper, narrower scope than
 ///   the full conversation.
 pub fn search_session_content(workspace_root: &str, session_ids: &[String], query: &str, own_messages_only: bool, generation: u64) -> String {
-    SEARCH_GENERATION.fetch_max(generation, Ordering::Relaxed);
+    // A plain store, not fetch_max: semantically, every call IS the latest request,
+    // full stop — "the latest caller wins" is the actual rule, not "the highest number
+    // wins". fetch_max ratcheted this upward forever, so once ANY higher generation had
+    // ever been seen, a legitimately newer but lower-numbered request (e.g. after
+    // searchRequestId resets to 0 on a webview reload, while this native library and
+    // its process-lifetime static stay loaded) could never win again and would silently
+    // return zero matches — caught by a test failure whose real cause turned out to be
+    // exactly this, not test-order flakiness.
+    SEARCH_GENERATION.store(generation, Ordering::Relaxed);
 
     let dir = match projects_dir(workspace_root) {
         Some(d) => d,
@@ -1350,10 +1358,7 @@ mod tests {
 
         set_home(&home);
         let ids = vec!["aaaa1111".to_string(), "bbbb2222".to_string()];
-        // Each test uses its own generation band, well clear of the others', so the
-        // shared process-wide SEARCH_GENERATION ratchet (parallel test threads) can't
-        // make one test's call see itself as superseded by another's.
-        let json = super::search_session_content(root, &ids, "quilt", false, 1_000);
+        let json = super::search_session_content(root, &ids, "quilt", false, 1);
         let _ = fs::remove_dir_all(&home);
 
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1382,9 +1387,8 @@ mod tests {
 
         set_home(&home);
         let ids = vec!["aaaa1111".to_string()];
-        // Own generation band — see the comment in the sibling test above.
-        let full = super::search_session_content(root, &ids, "quilt", false, 2_000);
-        let own_only = super::search_session_content(root, &ids, "quilt", true, 2_000);
+        let full = super::search_session_content(root, &ids, "quilt", false, 1);
+        let own_only = super::search_session_content(root, &ids, "quilt", true, 1);
         let _ = fs::remove_dir_all(&home);
 
         let full_v: serde_json::Value = serde_json::from_str(&full).unwrap();

--- a/claude-eclipse-core/src/session.rs
+++ b/claude-eclipse-core/src/session.rs
@@ -340,6 +340,27 @@ pub fn list_sessions(workspace_root: &str) -> String {
 
 static SEARCH_GENERATION: AtomicU64 = AtomicU64::new(0);
 
+/// Nearest valid UTF-8 char boundary at or BEFORE `idx` (never past it) — a portable
+/// stand-in for the standard library's floor_char_boundary, which is still
+/// nightly-only. Used to safely widen/narrow a byte-offset window computed against a
+/// DIFFERENT string's positions (see search_session_content's snippet extraction).
+fn floor_char_boundary(s: &str, idx: usize) -> usize {
+    let mut i = idx.min(s.len());
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Nearest valid UTF-8 char boundary at or AFTER `idx` (never past the string's end).
+fn ceil_char_boundary(s: &str, idx: usize) -> usize {
+    let mut i = idx.min(s.len());
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
+}
+
 /// @param generation this call's ordinal (the caller increments a per-session-search
 ///   counter each time the query changes) — used only for cancellation, unrelated to
 ///   the requestId round-tripped back to JS for discarding stale results.
@@ -410,9 +431,24 @@ pub fn search_session_content(workspace_root: &str, session_ids: &[String], quer
 
             let mut found: Option<String> = None;
             for text in &texts {
+                // pos/needle.len() are byte offsets into text.to_lowercase(), NOT into
+                // `text` itself — case-folding some characters changes their UTF-8 byte
+                // length (e.g. Turkish İ, German ẞ), so a straight `text[pos..]` slice
+                // using the LOWERCASED string's offsets can land mid-character in the
+                // ORIGINAL string and panic (confirmed: "ẞẞxquilt" searching "quilt"
+                // panics with "byte index 5 is not a char boundary"). Across the JNI
+                // boundary a Rust panic is undefined behavior (unwinding into a JVM
+                // frame), not a catchable Java exception — this crashed the whole
+                // Eclipse process with no JVM crash dump and nothing in dmesg, exactly
+                // matching a real user report. Snapping start/end to the nearest valid
+                // char boundary in `text` (not truncating to the lowercased string,
+                // which would need re-deriving positions entirely) keeps the fix local
+                // and the snippet's casing exactly as the user typed it.
                 if let Some(pos) = text.to_lowercase().find(&needle) {
-                    let start = text[..pos].char_indices().rev().nth(39).map(|(i, _)| i).unwrap_or(0);
-                    let end = (pos + needle.len() + 40).min(text.len());
+                    let raw_start = pos.saturating_sub(40).min(text.len());
+                    let raw_end = (pos + needle.len() + 40).min(text.len());
+                    let start = floor_char_boundary(text, raw_start);
+                    let end = ceil_char_boundary(text, raw_end);
                     found = Some(text[start..end].trim().to_string());
                     break;
                 }
@@ -1395,6 +1431,44 @@ mod tests {
         assert_eq!(full_v.as_array().unwrap().len(), 1, "full-conversation scope finds the assistant match: {full}");
         let own_v: serde_json::Value = serde_json::from_str(&own_only).unwrap();
         assert_eq!(own_v.as_array().unwrap().len(), 0, "own_messages_only must not match assistant text: {own_only}");
+    }
+
+    /// Regression test for a real crash: certain characters (German ẞ, Turkish İ, …)
+    /// change UTF-8 byte length when lowercased, so a match position found via
+    /// text.to_lowercase().find() does not correspond to the same byte offset in the
+    /// ORIGINAL text — slicing the original at that offset can land mid-character and
+    /// panic ("byte index N is not a char boundary"). Across the JNI boundary that
+    /// panic is undefined behavior (an unwind into a JVM-owned native frame), which
+    /// crashed a live user's whole Eclipse process with no JVM crash dump and nothing
+    /// in dmesg — exactly the kind of failure that looks like it isn't ours. Confirmed
+    /// via a standalone repro before this test existed: "ẞẞxquilt" searching "quilt"
+    /// panicked at the exact line this function now guards.
+    #[test]
+    fn search_session_content_snippet_survives_case_folding_byte_length_change() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir().join("claude-eclipse-session-search-unicode-home");
+        let root = r"C:\searchunicode";
+        let dir = home.join(".claude").join("projects").join("C--searchunicode");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&dir).unwrap();
+
+        // ẞ (U+1E9E, LATIN CAPITAL LETTER SHARP S) lowercases to "ß" — same character
+        // count but a different UTF-8 byte length, which is what desynchronizes the
+        // lowercased string's match offset from the original string's byte layout.
+        fs::write(dir.join("aaaa1111.jsonl"), concat!(
+            r#"{"type":"user","message":{"role":"user","content":"ẞẞxquilt talk"},"timestamp":"2026-07-01T10:00:00.000Z"}"#, "\n",
+        )).unwrap();
+
+        set_home(&home);
+        let ids = vec!["aaaa1111".to_string()];
+        // Must not panic — that's the entire point of this test.
+        let json = super::search_session_content(root, &ids, "quilt", false, 1);
+        let _ = fs::remove_dir_all(&home);
+
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1, "the match is still found despite the preceding multibyte characters: {json}");
+        assert!(arr[0]["snippet"].as_str().unwrap().to_lowercase().contains("quilt"));
     }
 
     /// Verified against the reference reader on 2026-07-10: the fixture below was

--- a/claude-eclipse-core/src/session.rs
+++ b/claude-eclipse-core/src/session.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -327,9 +328,27 @@ pub fn list_sessions(workspace_root: &str) -> String {
 // wins: the file is read line-by-line and abandoned the moment a match is
 // found, so a session's cost is bounded by how early the match falls, not by
 // its total length.
+//
+// Cooperative cancellation: every call publishes its own `generation` as the
+// latest one requested (SEARCH_GENERATION), then checks before starting each
+// session file whether a NEWER call has since arrived — the caller fires one
+// search per keystroke, so a slow typist's Nth keystroke would otherwise still
+// be scanning file #1 while the (N+1)th keystroke's results are already what
+// the UI wants. A superseded scan exits at the next file boundary rather than
+// running to completion for a result the UI is about to discard anyway.
 // ---------------------------------------------------------------------------
 
-pub fn search_session_content(workspace_root: &str, session_ids: &[String], query: &str) -> String {
+static SEARCH_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// @param generation this call's ordinal (the caller increments a per-session-search
+///   counter each time the query changes) — used only for cancellation, unrelated to
+///   the requestId round-tripped back to JS for discarding stale results.
+/// @param own_messages_only restrict the scan to `type:"user"` events (the user's own
+///   messages), skipping assistant turns entirely — a cheaper, narrower scope than
+///   the full conversation.
+pub fn search_session_content(workspace_root: &str, session_ids: &[String], query: &str, own_messages_only: bool, generation: u64) -> String {
+    SEARCH_GENERATION.fetch_max(generation, Ordering::Relaxed);
+
     let dir = match projects_dir(workspace_root) {
         Some(d) => d,
         None => return "[]".into(),
@@ -342,6 +361,9 @@ pub fn search_session_content(workspace_root: &str, session_ids: &[String], quer
     let mut results: Vec<serde_json::Value> = Vec::new();
 
     for session_id in session_ids {
+        if SEARCH_GENERATION.load(Ordering::Relaxed) != generation {
+            break;   // superseded by a newer keystroke's search — stop wasted I/O
+        }
         let path = dir.join(format!("{session_id}.jsonl"));
         let file = match fs::File::open(&path) {
             Ok(f) => f,
@@ -350,6 +372,11 @@ pub fn search_session_content(workspace_root: &str, session_ids: &[String], quer
         let reader = BufReader::new(file);
 
         for line in reader.lines() {
+            // Checked every line, not just every file: one large session shouldn't
+            // stall a supersede until its whole file is read.
+            if SEARCH_GENERATION.load(Ordering::Relaxed) != generation {
+                return serde_json::to_string(&results).unwrap_or_else(|_| "[]".into());
+            }
             let line = match line {
                 Ok(l) if !l.is_empty() => l,
                 _ => continue,
@@ -358,6 +385,9 @@ pub fn search_session_content(workspace_root: &str, session_ids: &[String], quer
                 Ok(v) => v,
                 Err(_) => continue,
             };
+            if own_messages_only && event["type"].as_str() != Some("user") {
+                continue;
+            }
 
             let mut texts: Vec<String> = Vec::new();
             if let Some(content) = event["message"]["content"].as_str() {
@@ -1320,7 +1350,10 @@ mod tests {
 
         set_home(&home);
         let ids = vec!["aaaa1111".to_string(), "bbbb2222".to_string()];
-        let json = super::search_session_content(root, &ids, "quilt");
+        // Each test uses its own generation band, well clear of the others', so the
+        // shared process-wide SEARCH_GENERATION ratchet (parallel test threads) can't
+        // make one test's call see itself as superseded by another's.
+        let json = super::search_session_content(root, &ids, "quilt", false, 1_000);
         let _ = fs::remove_dir_all(&home);
 
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1328,6 +1361,36 @@ mod tests {
         assert_eq!(arr.len(), 1, "only aaaa1111 matches within the requested subset: {json}");
         assert_eq!(arr[0]["sessionId"].as_str().unwrap(), "aaaa1111");
         assert!(arr[0]["snippet"].as_str().unwrap().to_lowercase().contains("quilt"));
+    }
+
+    /// A query that only appears in an assistant turn matches with the full-conversation
+    /// scope but not with own_messages_only — proving the scope actually excludes
+    /// assistant text rather than just being ignored.
+    #[test]
+    fn search_session_content_own_messages_only_excludes_assistant_text() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir().join("claude-eclipse-session-search-own-home");
+        let root = r"C:\searchownt";
+        let dir = home.join(".claude").join("projects").join("C--searchownt");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(dir.join("aaaa1111.jsonl"), concat!(
+            r#"{"type":"user","message":{"role":"user","content":"please help me"},"timestamp":"2026-07-01T10:00:00.000Z"}"#, "\n",
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"the quilt patch system works like this"}]},"timestamp":"2026-07-01T10:00:05.000Z"}"#, "\n",
+        )).unwrap();
+
+        set_home(&home);
+        let ids = vec!["aaaa1111".to_string()];
+        // Own generation band — see the comment in the sibling test above.
+        let full = super::search_session_content(root, &ids, "quilt", false, 2_000);
+        let own_only = super::search_session_content(root, &ids, "quilt", true, 2_000);
+        let _ = fs::remove_dir_all(&home);
+
+        let full_v: serde_json::Value = serde_json::from_str(&full).unwrap();
+        assert_eq!(full_v.as_array().unwrap().len(), 1, "full-conversation scope finds the assistant match: {full}");
+        let own_v: serde_json::Value = serde_json::from_str(&own_only).unwrap();
+        assert_eq!(own_v.as_array().unwrap().len(), 0, "own_messages_only must not match assistant text: {own_only}");
     }
 
     /// Verified against the reference reader on 2026-07-10: the fixture below was

--- a/claude-eclipse-core/src/session.rs
+++ b/claude-eclipse-core/src/session.rs
@@ -320,6 +320,80 @@ pub fn list_sessions(workspace_root: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// search_session_content — grep a caller-supplied subset of sessions for a
+// query string, message text only (not titles — the caller already knows how
+// to match those instantly from the cached list_sessions result, so it only
+// asks this for the sessions whose title didn't match). First hit per file
+// wins: the file is read line-by-line and abandoned the moment a match is
+// found, so a session's cost is bounded by how early the match falls, not by
+// its total length.
+// ---------------------------------------------------------------------------
+
+pub fn search_session_content(workspace_root: &str, session_ids: &[String], query: &str) -> String {
+    let dir = match projects_dir(workspace_root) {
+        Some(d) => d,
+        None => return "[]".into(),
+    };
+    let needle = query.to_lowercase();
+    if needle.is_empty() {
+        return "[]".into();
+    }
+
+    let mut results: Vec<serde_json::Value> = Vec::new();
+
+    for session_id in session_ids {
+        let path = dir.join(format!("{session_id}.jsonl"));
+        let file = match fs::File::open(&path) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        let reader = BufReader::new(file);
+
+        for line in reader.lines() {
+            let line = match line {
+                Ok(l) if !l.is_empty() => l,
+                _ => continue,
+            };
+            let event: serde_json::Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            let mut texts: Vec<String> = Vec::new();
+            if let Some(content) = event["message"]["content"].as_str() {
+                texts.push(strip_ide_preamble(content));
+            } else if let Some(blocks) = event["message"]["content"].as_array() {
+                for b in blocks {
+                    if b["type"].as_str() == Some("text") {
+                        texts.push(strip_ide_preamble(b["text"].as_str().unwrap_or("")));
+                    }
+                }
+            }
+
+            let mut found: Option<String> = None;
+            for text in &texts {
+                if let Some(pos) = text.to_lowercase().find(&needle) {
+                    let start = text[..pos].char_indices().rev().nth(39).map(|(i, _)| i).unwrap_or(0);
+                    let end = (pos + needle.len() + 40).min(text.len());
+                    found = Some(text[start..end].trim().to_string());
+                    break;
+                }
+            }
+
+            if let Some(snippet) = found {
+                results.push(serde_json::json!({
+                    "sessionId": session_id,
+                    "snippet": snippet,
+                }));
+                break;   // one match is enough — move to the next session
+            }
+        }
+    }
+
+    serde_json::to_string(&results).unwrap_or_else(|_| "[]".into())
+}
+
+// ---------------------------------------------------------------------------
 // load_session_history — read a specific session's JSONL and return the
 // conversation as an ordered list of render items so the GUI can reconstruct
 // EXACTLY how the live session looked:
@@ -1218,6 +1292,42 @@ mod tests {
             vec!["title-only stub", "real question text", "USER RENAMED TITLE"],
             "titles + last-activity order must match the PHP reader"
         );
+    }
+
+    /// Covers: a match on the first session found + snippet returned, no match on a
+    /// second, an id NOT in the search list skipped even though its file would match
+    /// (proving the caller-supplied subset is honored, not re-derived), and matching
+    /// is case-insensitive.
+    #[test]
+    fn search_session_content_finds_first_match_and_skips_others() {
+        let _env = ENV_LOCK.lock().unwrap();
+        let home = std::env::temp_dir().join("claude-eclipse-session-search-home");
+        let root = r"C:\searchtest";
+        let dir = home.join(".claude").join("projects").join("C--searchtest");
+        let _ = fs::remove_dir_all(&home);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(dir.join("aaaa1111.jsonl"), concat!(
+            r#"{"type":"user","message":{"role":"user","content":"talking about the quilt patch system"},"timestamp":"2026-07-01T10:00:00.000Z"}"#, "\n",
+        )).unwrap();
+        fs::write(dir.join("bbbb2222.jsonl"), concat!(
+            r#"{"type":"user","message":{"role":"user","content":"nothing relevant here"},"timestamp":"2026-07-01T10:00:00.000Z"}"#, "\n",
+        )).unwrap();
+        // Would match too, but deliberately left out of the search list below.
+        fs::write(dir.join("cccc3333.jsonl"), concat!(
+            r#"{"type":"user","message":{"role":"user","content":"QUILT also appears here"},"timestamp":"2026-07-01T10:00:00.000Z"}"#, "\n",
+        )).unwrap();
+
+        set_home(&home);
+        let ids = vec!["aaaa1111".to_string(), "bbbb2222".to_string()];
+        let json = super::search_session_content(root, &ids, "quilt");
+        let _ = fs::remove_dir_all(&home);
+
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 1, "only aaaa1111 matches within the requested subset: {json}");
+        assert_eq!(arr[0]["sessionId"].as_str().unwrap(), "aaaa1111");
+        assert!(arr[0]["snippet"].as_str().unwrap().to_lowercase().contains("quilt"));
     }
 
     /// Verified against the reference reader on 2026-07-10: the fixture below was

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -167,7 +167,7 @@
     </div>
     <div class="hist-search">
       <input id="hist-search" type="text" placeholder="Search sessions…" oninput="onHistorySearchInput()">
-      <span class="hist-search-scope" id="hist-search-scope" title="Also search conversation content" onclick="toggleContentSearch()">__SEARCH__</span>
+      <span class="hist-search-scope" id="hist-search-scope" title="Search: titles only" onclick="cycleSearchScope()">__SEARCH__</span>
     </div>
     <div id="history-list"></div>
     <div id="history-web"><div class="h-empty">Web history isn't available yet.</div></div>

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -165,7 +165,10 @@
       <div class="hist-tab active" id="hist-tab-local" onclick="histTab('local')">__MONITOR__ Local</div>
       <div class="hist-tab" id="hist-tab-web" onclick="histTab('web')">__GLOBE__ Web</div>
     </div>
-    <div class="hist-search"><input id="hist-search" type="text" placeholder="Search sessions…" oninput="renderHistoryList()"></div>
+    <div class="hist-search">
+      <input id="hist-search" type="text" placeholder="Search sessions…" oninput="onHistorySearchInput()">
+      <span class="hist-search-scope" id="hist-search-scope" title="Also search conversation content" onclick="toggleContentSearch()">__SEARCH__</span>
+    </div>
     <div id="history-list"></div>
     <div id="history-web"><div class="h-empty">Web history isn't available yet.</div></div>
   </div>

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -167,7 +167,7 @@
     </div>
     <div class="hist-search">
       <input id="hist-search" type="text" placeholder="Search sessions…" oninput="onHistorySearchInput()">
-      <span class="hist-search-scope" id="hist-search-scope" title="Search: titles only" onclick="cycleSearchScope()">__SEARCH__</span>
+      <span class="hist-search-scope" id="hist-search-scope" title="Search: titles only" onclick="cycleSearchScope(event)">__SEARCH__</span>
     </div>
     <div id="history-list"></div>
     <div id="history-web"><div class="h-empty">Web history isn't available yet.</div></div>

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -53,6 +53,55 @@ function parseUserContent(s) {
 
 let histSessions = [], histLoading = false, histLoaded = false;
 function setHistoryLoading(v) { histLoading = v; }   // list shows "Loading…"; button stays the clock
+
+/* Content search toggle: titles-only (default) vs. titles + message text. Persisted
+   across panel opens/restarts — the user's chosen search scope, not a session detail. */
+let contentSearchEnabled = false;
+try { contentSearchEnabled = localStorage.getItem('claude.histContentSearch') === '1'; } catch (e) {}
+// Bumped on every content search kicked off; a result whose requestId doesn't match
+// the current value is stale (the user kept typing) and is discarded on arrival.
+let searchRequestId = 0;
+let searchInFlight = false;
+// sessionId -> snippet, for the content matches found by the CURRENT search only.
+// Cleared at the start of each new search — never appended to across searches.
+let contentMatches = {};
+
+function toggleContentSearch() {
+  contentSearchEnabled = !contentSearchEnabled;
+  try { localStorage.setItem('claude.histContentSearch', contentSearchEnabled ? '1' : '0'); } catch (e) {}
+  const btn = document.getElementById('hist-search-scope');
+  if (btn) btn.classList.toggle('active', contentSearchEnabled);
+  renderHistoryList();
+}
+
+function runContentSearch(query) {
+  const myId = ++searchRequestId;
+  contentMatches = {};
+  if (!query || !window._searchSessionContentAsync) { searchInFlight = false; updateSearchBusy(); return; }
+  // Only the sessions the title filter didn't already catch — a title match is
+  // shown regardless, so there's no reason to also grep that session's body.
+  const q = query.toLowerCase();
+  const idsToScan = histSessions
+    .filter(s => !(s.display || '').toLowerCase().includes(q))
+    .map(s => s.sessionId);
+  if (!idsToScan.length) { searchInFlight = false; updateSearchBusy(); return; }
+  searchInFlight = true;
+  updateSearchBusy();
+  window._searchSessionContentAsync(JSON.stringify(idsToScan), query, String(myId));
+}
+window.onSessionSearchResult = function(json, requestId) {
+  if (Number(requestId) !== searchRequestId) return;   // superseded by a later keystroke
+  searchInFlight = false;
+  updateSearchBusy();
+  let matches = [];
+  try { matches = JSON.parse(json || '[]'); } catch (e) {}
+  matches.forEach(m => { contentMatches[m.sessionId] = m.snippet; });
+  renderHistoryList();
+};
+function updateSearchBusy() {
+  const btn = document.getElementById('hist-search-scope');
+  if (btn) btn.classList.toggle('busy', searchInFlight);
+}
 /* Load the session list off the UI thread (the first call extracts the bundled
    PHP runtime + spawns php, which would otherwise freeze the click). */
 function loadHistoryAsync() {
@@ -90,6 +139,12 @@ function openHistoryPanel(resumeInPlace) {
   historyResumeInPlace = resumeInPlace;
   histTab('local');
   const s = document.getElementById('hist-search'); if (s) s.value = '';
+  // A fresh search each time the panel opens — no stale matches or in-flight
+  // request from the last time it was open.
+  searchRequestId++; searchInFlight = false; contentMatches = {};
+  updateSearchBusy();
+  const scopeBtn = document.getElementById('hist-search-scope');
+  if (scopeBtn) scopeBtn.classList.toggle('active', contentSearchEnabled);
   // Open the panel immediately; show cached results if we have them, otherwise a
   // "Loading…" state — and (re)load in the background either way.
   renderHistoryList();
@@ -174,14 +229,27 @@ function histTab(which) {
   document.querySelector('.hist-search').style.display = local ? '' : 'none';
   document.getElementById('history-web').style.display = local ? 'none' : '';
 }
+/* oninput handler for #hist-search: title matches render instantly from the
+   already-cached list; a content search (if enabled) runs in the background and
+   its matches get merged in via onSessionSearchResult as they arrive. */
+function onHistorySearchInput() {
+  renderHistoryList();
+  if (contentSearchEnabled) {
+    const q = document.getElementById('hist-search').value;
+    runContentSearch(q);
+  }
+}
 function renderHistoryList() {
   const q = (document.getElementById('hist-search') ? document.getElementById('hist-search').value : '').toLowerCase();
   const list = document.getElementById('history-list');
   list.innerHTML = '';
   if (histLoading && !histLoaded) { list.innerHTML = '<div class="h-empty">Loading…</div>'; return; }
-  const items = histSessions.filter(s => (s.display || '').toLowerCase().includes(q));
+  const items = histSessions.filter(s =>
+    (s.display || '').toLowerCase().includes(q) ||
+    (contentSearchEnabled && Object.prototype.hasOwnProperty.call(contentMatches, s.sessionId)));
   if (!items.length) {
-    list.innerHTML = '<div class="h-empty">' + (histSessions.length ? 'No matches.' : 'No past conversations yet.') + '</div>';
+    const empty = !histSessions.length ? 'No past conversations yet.' : (searchInFlight ? 'Searching…' : 'No matches.');
+    list.innerHTML = '<div class="h-empty">' + empty + '</div>';
     return;
   }
   items.forEach(s => {
@@ -190,6 +258,12 @@ function renderHistoryList() {
     const title = document.createElement('div'); title.className = 'h-title'; title.textContent = stripContext(s.display) || '(untitled)';
     const time = document.createElement('div'); time.className = 'h-time'; time.textContent = relTime(s.timestamp);
     main.appendChild(title); main.appendChild(time);
+    const titleMatched = (s.display || '').toLowerCase().includes(q);
+    if (q && !titleMatched && contentMatches[s.sessionId]) {
+      const snippet = document.createElement('div'); snippet.className = 'h-snippet';
+      snippet.textContent = contentMatches[s.sessionId];
+      main.appendChild(snippet);
+    }
     const actions = document.createElement('div'); actions.className = 'h-actions';
     const rename = document.createElement('span'); rename.className = 'h-action h-rename'; rename.title = 'Rename';
     rename.innerHTML = ICONS.PENCIL;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -54,10 +54,17 @@ function parseUserContent(s) {
 let histSessions = [], histLoading = false, histLoaded = false;
 function setHistoryLoading(v) { histLoading = v; }   // list shows "Loading…"; button stays the clock
 
-/* Content search toggle: titles-only (default) vs. titles + message text. Persisted
-   across panel opens/restarts — the user's chosen search scope, not a session detail. */
-let contentSearchEnabled = false;
-try { contentSearchEnabled = localStorage.getItem('claude.histContentSearch') === '1'; } catch (e) {}
+/* Search scope: 'title' (default) → 'own' (titles + the user's own messages) →
+   'all' (titles + the full conversation, including Claude's replies) → back to
+   'title'. Persisted across panel opens/restarts — the user's chosen search
+   scope, not a session detail. */
+const SEARCH_SCOPES = ['title', 'own', 'all'];
+const SEARCH_SCOPE_LABEL = { title: 'Search: titles only', own: 'Search: titles + my messages', all: 'Search: titles + full conversation' };
+let searchScope = 'title';
+try {
+  const saved = localStorage.getItem('claude.histSearchScope');
+  if (SEARCH_SCOPES.includes(saved)) searchScope = saved;
+} catch (e) {}
 // Bumped on every content search kicked off; a result whose requestId doesn't match
 // the current value is stale (the user kept typing) and is discarded on arrival.
 let searchRequestId = 0;
@@ -66,18 +73,27 @@ let searchInFlight = false;
 // Cleared at the start of each new search — never appended to across searches.
 let contentMatches = {};
 
-function toggleContentSearch() {
-  contentSearchEnabled = !contentSearchEnabled;
-  try { localStorage.setItem('claude.histContentSearch', contentSearchEnabled ? '1' : '0'); } catch (e) {}
+function cycleSearchScope() {
+  searchScope = SEARCH_SCOPES[(SEARCH_SCOPES.indexOf(searchScope) + 1) % SEARCH_SCOPES.length];
+  try { localStorage.setItem('claude.histSearchScope', searchScope); } catch (e) {}
+  updateSearchScopeButton();
+  onHistorySearchInput();
+}
+const SEARCH_SCOPE_ICON = { title: 'SEARCH', own: 'SEARCHOWN', all: 'SEARCHALL' };
+function updateSearchScopeButton() {
   const btn = document.getElementById('hist-search-scope');
-  if (btn) btn.classList.toggle('active', contentSearchEnabled);
-  renderHistoryList();
+  if (!btn) return;
+  btn.classList.toggle('active', searchScope !== 'title');
+  btn.title = SEARCH_SCOPE_LABEL[searchScope];
+  btn.innerHTML = ICONS[SEARCH_SCOPE_ICON[searchScope]];
 }
 
 function runContentSearch(query) {
   const myId = ++searchRequestId;
   contentMatches = {};
-  if (!query || !window._searchSessionContentAsync) { searchInFlight = false; updateSearchBusy(); return; }
+  if (!query || searchScope === 'title' || !window._searchSessionContentAsync) {
+    searchInFlight = false; updateSearchBusy(); return;
+  }
   // Only the sessions the title filter didn't already catch — a title match is
   // shown regardless, so there's no reason to also grep that session's body.
   const q = query.toLowerCase();
@@ -87,7 +103,7 @@ function runContentSearch(query) {
   if (!idsToScan.length) { searchInFlight = false; updateSearchBusy(); return; }
   searchInFlight = true;
   updateSearchBusy();
-  window._searchSessionContentAsync(JSON.stringify(idsToScan), query, String(myId));
+  window._searchSessionContentAsync(JSON.stringify(idsToScan), query, String(myId), searchScope === 'own');
 }
 window.onSessionSearchResult = function(json, requestId) {
   if (Number(requestId) !== searchRequestId) return;   // superseded by a later keystroke
@@ -143,8 +159,7 @@ function openHistoryPanel(resumeInPlace) {
   // request from the last time it was open.
   searchRequestId++; searchInFlight = false; contentMatches = {};
   updateSearchBusy();
-  const scopeBtn = document.getElementById('hist-search-scope');
-  if (scopeBtn) scopeBtn.classList.toggle('active', contentSearchEnabled);
+  updateSearchScopeButton();
   // Open the panel immediately; show cached results if we have them, otherwise a
   // "Loading…" state — and (re)load in the background either way.
   renderHistoryList();
@@ -234,7 +249,7 @@ function histTab(which) {
    its matches get merged in via onSessionSearchResult as they arrive. */
 function onHistorySearchInput() {
   renderHistoryList();
-  if (contentSearchEnabled) {
+  if (searchScope !== 'title') {
     const q = document.getElementById('hist-search').value;
     runContentSearch(q);
   }
@@ -246,7 +261,7 @@ function renderHistoryList() {
   if (histLoading && !histLoaded) { list.innerHTML = '<div class="h-empty">Loading…</div>'; return; }
   const items = histSessions.filter(s =>
     (s.display || '').toLowerCase().includes(q) ||
-    (contentSearchEnabled && Object.prototype.hasOwnProperty.call(contentMatches, s.sessionId)));
+    (searchScope !== 'title' && Object.prototype.hasOwnProperty.call(contentMatches, s.sessionId)));
   if (!items.length) {
     const empty = !histSessions.length ? 'No past conversations yet.' : (searchInFlight ? 'Searching…' : 'No matches.');
     list.innerHTML = '<div class="h-empty">' + empty + '</div>';

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -73,9 +73,15 @@ let searchInFlight = false;
 // Cleared at the start of each new search — never appended to across searches.
 let contentMatches = {};
 
-function cycleSearchScope() {
+function cycleSearchScope(e) {
+  // Without this, the click bubbles from the __SEARCH__-substituted <svg> the user
+  // actually clicked — updateSearchScopeButton()'s innerHTML swap below detaches
+  // that svg from the document before the event finishes bubbling, so ui.js's
+  // document-level click-outside check sees a detached e.target, reads it as
+  // "outside the panel", and closes History along with the scope change.
+  if (e) e.stopPropagation();
   searchScope = SEARCH_SCOPES[(SEARCH_SCOPES.indexOf(searchScope) + 1) % SEARCH_SCOPES.length];
-  try { localStorage.setItem('claude.histSearchScope', searchScope); } catch (e) {}
+  try { localStorage.setItem('claude.histSearchScope', searchScope); } catch (err) {}
   updateSearchScopeButton();
   onHistorySearchInput();
 }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
@@ -27,6 +27,7 @@ const ICONS = {
   STOP: '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>',
   UPLOAD: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 16V4M7 9l5-5 5 5"/><path d="M4 16v3a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-3"/></svg>',
   GLOBE: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="8.5"/><path d="M3.5 12h17M12 3.5c2.5 2.5 2.5 14.5 0 17M12 3.5c-2.5 2.5-2.5 14.5 0 17"/></svg>',
+  SEARCH: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="10.5" cy="10.5" r="6.5"/><path d="M20 20l-5-5"/></svg>',
   CHECK: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12l5 5 9-10"/></svg>',
   PENCIL: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 20h4L19 9l-4-4L4 16z"/><path d="M14 6l4 4"/></svg>',
   MAP: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M9 4L3 6v14l6-2 6 2 6-2V4l-6 2-6-2z"/><path d="M9 4v14M15 6v14"/></svg>',

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
@@ -28,6 +28,10 @@ const ICONS = {
   UPLOAD: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 16V4M7 9l5-5 5 5"/><path d="M4 16v3a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-3"/></svg>',
   GLOBE: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="8.5"/><path d="M3.5 12h17M12 3.5c2.5 2.5 2.5 14.5 0 17M12 3.5c-2.5 2.5-2.5 14.5 0 17"/></svg>',
   SEARCH: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="10.5" cy="10.5" r="6.5"/><path d="M20 20l-5-5"/></svg>',
+  /* search-scope: single user, for "titles + my own messages" */
+  SEARCHOWN: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="8" r="3.2"/><path d="M5.5 19.5a6.5 6.5 0 0 1 13 0"/></svg>',
+  /* search-scope: two chat bubbles, for "titles + full conversation" */
+  SEARCHALL: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h10v6H8l-3 3v-3H4z"/><path d="M12 12.5h2l3 3v-3h2v-6h-3"/></svg>',
   CHECK: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12l5 5 9-10"/></svg>',
   PENCIL: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 20h4L19 9l-4-4L4 16z"/><path d="M14 6l4 4"/></svg>',
   MAP: '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M9 4L3 6v14l6-2 6 2 6-2V4l-6 2-6-2z"/><path d="M9 4v14M15 6v14"/></svg>',

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/panels.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/panels.css
@@ -59,14 +59,20 @@
 .hist-tab { flex: 1; display: flex; align-items: center; justify-content: center; gap: 6px; padding: 5px 8px;
   border-radius: 5px; color: var(--fg-dim); font-size: 12px; cursor: pointer; }
 .hist-tab.active { background: var(--bg-hover); color: var(--fg); }
-.hist-search { margin-bottom: 4px; }
-.hist-search input { width: 100%; background: var(--bg-code); border: 1px solid var(--border); border-radius: 6px;
+.hist-search { margin-bottom: 4px; display: flex; align-items: center; gap: 6px; }
+.hist-search input { flex: 1; min-width: 0; background: var(--bg-code); border: 1px solid var(--border); border-radius: 6px;
   padding: 6px 9px; color: var(--fg); font-size: 12px; outline: none; }
 .hist-search input:focus { border-color: var(--accent); }
+.hist-search-scope { display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+  width: 22px; height: 22px; border-radius: 5px; color: var(--fg-faint); cursor: pointer; }
+.hist-search-scope:hover { color: var(--fg); background: var(--bg-hover); }
+.hist-search-scope.active { color: var(--accent); background: var(--bg-hover); }
+.hist-search-scope.busy { animation: spin .8s linear infinite; }
 #history-list { overflow-y: auto; }
 #history-list .item { align-items: center; gap: 6px; }
 #history-list .h-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 #history-list .h-title { color: var(--fg); font-size: 12.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+#history-list .h-snippet { color: var(--fg-dim); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 #history-list .h-time { color: var(--fg-faint); font-size: 10.5px; }
 #history-list .h-actions { display: flex; gap: 2px; flex-shrink: 0; }
 #history-list .h-action { color: var(--fg-faint); padding: 4px; border-radius: 4px; visibility: hidden; cursor: pointer; }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/NativeCore.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/NativeCore.java
@@ -474,8 +474,14 @@ public final class NativeCore {
      * match per session wins. Returns a JSON array of {@code {sessionId, snippet}}
      * for sessions that matched. Meant to run only over sessions whose title didn't
      * already match — the caller filters those out first.
+     *
+     * @param ownMessagesOnly restrict the scan to the user's own messages, skipping
+     *     assistant turns — a narrower scope than the full conversation.
+     * @param generation this search's ordinal in the caller's own sequence (bump on
+     *     every new query). Lets an in-progress scan notice a newer one has since
+     *     started and stop early instead of finishing a scan the UI will discard.
      */
-    public static native String sessionSearchContent(String workspaceRoot, String sessionIdsJson, String query);
+    public static native String sessionSearchContent(String workspaceRoot, String sessionIdsJson, String query, boolean ownMessagesOnly, long generation);
 
     /**
      * Deletes one local session jsonl (id guarded against escaping the projects

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/NativeCore.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/NativeCore.java
@@ -470,6 +470,14 @@ public final class NativeCore {
     public static native String sessionLoad(String workspaceRoot, String sessionId);
 
     /**
+     * Greps the given sessions' message text (not titles) for {@code query}, first
+     * match per session wins. Returns a JSON array of {@code {sessionId, snippet}}
+     * for sessions that matched. Meant to run only over sessions whose title didn't
+     * already match — the caller filters those out first.
+     */
+    public static native String sessionSearchContent(String workspaceRoot, String sessionIdsJson, String query);
+
+    /**
      * Deletes one local session jsonl (id guarded against escaping the projects
      * directory). Returns true when the file was actually removed.
      */

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -323,7 +323,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             final String sessionIdsJson = a.length > 0 && a[0] instanceof String s ? s : "[]";
             final String query = a.length > 1 && a[1] instanceof String s ? s : "";
             final String requestId = a.length > 2 && a[2] instanceof String s ? s : "";
-            final boolean ownMessagesOnly = a.length > 3 && a[3] instanceof Boolean b && b;
+            final boolean ownMessagesOnly = a.length > 3 && a[3] instanceof Boolean own && own;
             // Same ordinal as requestId — reused as the cancellation generation Rust
             // checks between session files (see NativeCore#sessionSearchContent).
             long gen; try { gen = Long.parseLong(requestId); } catch (NumberFormatException e) { gen = 0; }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -323,8 +323,13 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             final String sessionIdsJson = a.length > 0 && a[0] instanceof String s ? s : "[]";
             final String query = a.length > 1 && a[1] instanceof String s ? s : "";
             final String requestId = a.length > 2 && a[2] instanceof String s ? s : "";
+            final boolean ownMessagesOnly = a.length > 3 && a[3] instanceof Boolean b && b;
+            // Same ordinal as requestId — reused as the cancellation generation Rust
+            // checks between session files (see NativeCore#sessionSearchContent).
+            long gen; try { gen = Long.parseLong(requestId); } catch (NumberFormatException e) { gen = 0; }
+            final long generation = gen;
             new Thread(() -> {
-                String json = safeSessionSearchContent(root, sessionIdsJson, query);
+                String json = safeSessionSearchContent(root, sessionIdsJson, query, ownMessagesOnly, generation);
                 Display.getDefault().asyncExec(() -> {
                     if (b != null && !b.isDisposed() && pageLoaded) {
                         b.execute("window.onSessionSearchResult && window.onSessionSearchResult('"
@@ -2066,8 +2071,8 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
 
     /** @param root captured on the UI thread before the scan, same reason as
      *  {@link #safeSessionList(String)}. */
-    private String safeSessionSearchContent(String root, String sessionIdsJson, String query) {
-        try { return NativeCore.sessionSearchContent(root, sessionIdsJson, query); }
+    private String safeSessionSearchContent(String root, String sessionIdsJson, String query, boolean ownMessagesOnly, long generation) {
+        try { return NativeCore.sessionSearchContent(root, sessionIdsJson, query, ownMessagesOnly, generation); }
         catch (Throwable t) { return "[]"; }
     }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -96,6 +96,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     @SuppressWarnings("unused") private BrowserFunction newSessionFn;
     @SuppressWarnings("unused") private BrowserFunction listSessionsFn;
     @SuppressWarnings("unused") private BrowserFunction listSessionsAsyncFn;
+    @SuppressWarnings("unused") private BrowserFunction searchSessionContentFn;
     @SuppressWarnings("unused") private BrowserFunction loadSessionFn;
     @SuppressWarnings("unused") private BrowserFunction deleteSessionFn;
     @SuppressWarnings("unused") private BrowserFunction renameSessionFn;
@@ -311,6 +312,26 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
                     }
                 });
             }, "claude-history-load").start();
+            return null;
+        });
+        // Content search: greps the given sessions' message text off the UI thread.
+        // requestId round-trips so JS can discard a result that arrived after a
+        // newer search superseded it (the user kept typing).
+        searchSessionContentFn = new SimpleFunction(browser, "_searchSessionContentAsync", a -> {
+            final Browser b = browser;
+            final String root = activeRoot();
+            final String sessionIdsJson = a.length > 0 && a[0] instanceof String s ? s : "[]";
+            final String query = a.length > 1 && a[1] instanceof String s ? s : "";
+            final String requestId = a.length > 2 && a[2] instanceof String s ? s : "";
+            new Thread(() -> {
+                String json = safeSessionSearchContent(root, sessionIdsJson, query);
+                Display.getDefault().asyncExec(() -> {
+                    if (b != null && !b.isDisposed() && pageLoaded) {
+                        b.execute("window.onSessionSearchResult && window.onSessionSearchResult('"
+                                + esc(json) + "', '" + esc(requestId) + "')");
+                    }
+                });
+            }, "claude-history-search").start();
             return null;
         });
         loadSessionFn  = new SimpleFunction(browser, "_loadSession", a ->
@@ -2040,6 +2061,13 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
 
     private String safeSessionLoad(String id) {
         try { return NativeCore.sessionLoad(activeRoot(), id); }
+        catch (Throwable t) { return "[]"; }
+    }
+
+    /** @param root captured on the UI thread before the scan, same reason as
+     *  {@link #safeSessionList(String)}. */
+    private String safeSessionSearchContent(String root, String sessionIdsJson, String query) {
+        try { return NativeCore.sessionSearchContent(root, sessionIdsJson, query); }
         catch (Throwable t) { return "[]"; }
     }
 


### PR DESCRIPTION
Adds a scope to History's search: title (unchanged default), your own messages, or the full conversation — so you can find a past conversation by something that was actually said in it, not just how it was titled.