### PR TITLE
Fix blank terminal columns on themes with auto-hiding scrollbars

### DIFF
--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/Constants.java
@@ -44,6 +44,18 @@ public final class Constants {
      *  freeze, with no "user sent input" seam to hook a bypass onto. */
     public static final String PREF_SMART_SCROLL_LOCK = "smartScrollLock";
 
+    /** Give the Claude Terminal a persistent vertical scrollbar instead of the theme's overlay
+     *  (auto-hiding) one. An overlay scrollbar is painted ON TOP of the terminal canvas and
+     *  fades out after scrolling; GTK then damages exactly the strip it occupied, and SWT
+     *  drops that draw event as a spurious scrollbar redraw (Scrollable#gtk_draw, SWT bug
+     *  546248), so the NO_BACKGROUND terminal canvas never repaints those columns — they
+     *  flicker while the bar fades and go blank/stale afterwards. A persistent scrollbar sits
+     *  BESIDE the canvas, so the strip is never damaged and the column count accounts for it.
+     *
+     *  <p>Only ever offered where the platform actually uses overlay scrollbars — see
+     *  ClaudePreferencePage#overlayScrollbarsInUse; setting it has no effect elsewhere. */
+    public static final String PREF_CLI_PERSISTENT_SCROLLBAR = "cliPersistentScrollbar";
+
     /** Set once the user dismisses the Ctrl+Click hint bar in the Claude Terminal view (per-workspace). */
     public static final String PREF_CLI_CTRLCLICK_HINT_DISMISSED = "cliCtrlClickHintDismissed";
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeCliView.java
@@ -56,6 +56,7 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Scrollable;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.ToolBar;
@@ -159,7 +160,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
     private Color bgColor;
     private IPropertyChangeListener fontChangeListener;
     private IPropertyChangeListener colorChangeListener;
-    private IPropertyChangeListener statusPrefListener;
+    private IPropertyChangeListener prefListener;
     private Action scrollLockAction;
 
     /** Shared entity resolver registry for Ctrl-click navigation, one per view. */
@@ -251,22 +252,28 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         };
         JFaceResources.getColorRegistry().addListener(colorChangeListener);
 
-        // Live-apply status-line preference changes to already-running sessions (enable
-        // toggle + per-element toggles), so an edit in Preferences takes effect without
-        // relaunching the terminal — mirroring the Claude Code (GUI) view. The refresh
-        // interval still binds on next launch (it's the external CLI's re-invocation cadence).
-        statusPrefListener = event -> {
+        // Live-apply preference changes to already-running sessions, so an edit in Preferences
+        // takes effect without relaunching the terminal — mirroring the Claude Code (GUI) view.
+        // Status line: the enable toggle + the per-element toggles; the refresh interval still
+        // binds on next launch (it's the external CLI's re-invocation cadence). Scrollbar mode:
+        // a plain SWT switch on the canvas, so it flips either way at any time.
+        prefListener = event -> {
             String p = event.getProperty();
-            if (p == null || !p.startsWith("statusline")) return;
+            if (p == null) return;
+            boolean statusline = p.startsWith("statusline");
+            boolean scrollbar = Constants.PREF_CLI_PERSISTENT_SCROLLBAR.equals(p);
+            if (!statusline && !scrollbar) return;
             display.asyncExec(() -> {
                 if (viewDisposed || tabFolder == null || tabFolder.isDisposed()) return;
                 for (CTabItem item : tabFolder.getItems()) {
                     TerminalSession session = (TerminalSession) item.getData();
-                    if (session != null) session.applyStatusPrefsLive();
+                    if (session == null) continue;
+                    if (statusline) session.applyStatusPrefsLive();
+                    else session.applyScrollbarMode();
                 }
             });
         };
-        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(statusPrefListener);
+        Activator.getDefault().getPreferenceStore().addPropertyChangeListener(prefListener);
     }
 
     private void applyTheme() {
@@ -766,10 +773,10 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             JFaceResources.getColorRegistry().removeListener(colorChangeListener);
             colorChangeListener = null;
         }
-        if (statusPrefListener != null) {
-            try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(statusPrefListener); }
+        if (prefListener != null) {
+            try { Activator.getDefault().getPreferenceStore().removePropertyChangeListener(prefListener); }
             catch (Throwable ignored) {}
-            statusPrefListener = null;
+            prefListener = null;
         }
         if (tabFolder != null && !tabFolder.isDisposed()) {
             for (CTabItem item : tabFolder.getItems()) {
@@ -1149,6 +1156,7 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
             if (termRoot != null && !termRoot.isDisposed()) {
                 termRoot.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
             }
+            applyScrollbarMode();
             if (Activator.getDefault().getPreferenceStore()
                     .getBoolean(Constants.PREF_STATUSLINE_ENABLED)) {
                 statusBar = new ClaudeStatusBar(content);
@@ -1321,6 +1329,25 @@ public class ClaudeCliView extends ViewPart implements IShowInTarget {
         void focus() {
             if (!disposed && termControl != null && !termControl.isDisposed()) {
                 termControl.setFocus();
+            }
+        }
+
+        /**
+         * Applies {@link Constants#PREF_CLI_PERSISTENT_SCROLLBAR} — a persistent vertical
+         * scrollbar beside the terminal canvas rather than the theme's overlay one painted over
+         * it — to this session. That constant documents the rendering artifact it avoids.
+         *
+         * <p>Both directions are unconditional: asking for the mode the platform already uses is
+         * how SWT itself no-ops (on Windows and macOS {@code setScrollbarsMode} does nothing at
+         * all), and the preference is only ever shown where the switch has an effect — see
+         * {@code ClaudePreferencePage#overlayScrollbarsInUse}.
+         */
+        void applyScrollbarMode() {
+            if (termControl == null || termControl.isDisposed()) return;
+            if (termControl.getControl() instanceof Scrollable canvas && !canvas.isDisposed()) {
+                canvas.setScrollbarsMode(Activator.getDefault().getPreferenceStore()
+                        .getBoolean(Constants.PREF_CLI_PERSISTENT_SCROLLBAR)
+                                ? SWT.NONE : SWT.SCROLLBAR_OVERLAY);
             }
         }
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferenceInitializer.java
@@ -23,6 +23,7 @@ public class ClaudePreferenceInitializer extends AbstractPreferenceInitializer {
         store.setDefault(Constants.PREF_DEBUG_MODE, false);
         store.setDefault(Constants.PREF_SCROLL_LOCK_DEFAULT, false);
         store.setDefault(Constants.PREF_SMART_SCROLL_LOCK, false);
+        store.setDefault(Constants.PREF_CLI_PERSISTENT_SCROLLBAR, true);
         store.setDefault(Constants.PREF_CLI_CTRLCLICK_HINT_DISMISSED, false);
         store.setDefault(Constants.PREF_CLI_RENAME_HINT_SHOWN, false);
 

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudePreferencePage.java
@@ -164,6 +164,13 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                         + "Scroll Lock is on",
                 getFieldEditorParent()));
 
+        if (overlayScrollbarsInUse(getFieldEditorParent())) {
+            addField(new BooleanFieldEditor(
+                    Constants.PREF_CLI_PERSISTENT_SCROLLBAR,
+                    "Persistent vertical scrollbar",
+                    getFieldEditorParent()));
+        }
+
         Label statusSeparator = new Label(getFieldEditorParent(), SWT.SEPARATOR | SWT.HORIZONTAL);
         statusSeparator.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 
@@ -314,6 +321,30 @@ public class ClaudePreferencePage extends FieldEditorPreferencePage implements I
                 Constants.PREF_SPINNER_CUSTOM,
                 "Use custom spinner verbs",
                 getFieldEditorParent()));
+    }
+
+    /**
+     * Whether this platform paints overlay (auto-hiding) scrollbars <em>and</em> lets a widget
+     * opt out of them — the only situation in which
+     * {@link Constants#PREF_CLI_PERSISTENT_SCROLLBAR} changes anything, and so the only
+     * situation in which the page offers it.
+     *
+     * <p>Both halves are answered by asking SWT rather than by testing the OS: a throwaway
+     * scrollable reports the mode it would be given, and toggling it proves whether the switch
+     * is honoured. That keeps macOS out (it reports overlay scrollbars, but
+     * {@link org.eclipse.swt.widgets.Scrollable#setScrollbarsMode(int)} is a no-op there, as on
+     * Windows) and equally keeps out a GTK session launched with {@code GTK_OVERLAY_SCROLLING=0},
+     * where the artifact cannot occur in the first place.
+     */
+    private static boolean overlayScrollbarsInUse(Composite parent) {
+        Composite probe = new Composite(parent, SWT.V_SCROLL);
+        try {
+            if (probe.getScrollbarsMode() != SWT.SCROLLBAR_OVERLAY) return false;
+            probe.setScrollbarsMode(SWT.NONE);
+            return probe.getScrollbarsMode() != SWT.SCROLLBAR_OVERLAY;
+        } finally {
+            probe.dispose();
+        }
     }
 
     /**


### PR DESCRIPTION
### Fixed overlay scrollbars rendering issue for Claude Terminal on Linux platform:
When scrollbars are visible -- everything OK, as expected:
<img width="855" height="210" alt="1" src="https://github.com/user-attachments/assets/ac95f1d1-9699-48a8-9ec9-5ffe2224fdef" />
When scrollbars fade out -- a few chars on the right are missing due to SWT bug:
<img width="855" height="210" alt="2" src="https://github.com/user-attachments/assets/c12722c3-5119-455e-ad02-dcc8bd99a3f8" />

**Solution:** make vertical scrollbar always visible and introduce a preference for this (ON by default and the preference is only shown on applicable platforms).

------

On GTK themes that draw the vertical scrollbar as a fading overlay — the KDE default among them — the rightmost columns of a Claude Terminal tab go blank or stale, and flicker while the bar fades out.

Such a scrollbar is painted over the canvas rather than beside it, so when it fades GTK damages exactly the rectangle it occupied. SWT's Scrollable.gtk_draw discards every draw event whose clip has the scrollbar's width and height — an optimisation against the spurious scrollbar redraws GTK emits on leave-notify (SWT bug 546248) — so that damage never becomes an SWT.Paint. The terminal canvas is NO_BACKGROUND and paints its own cells, so the strip keeps whatever pixels the fading bar left behind. The canvas cannot repair it either: a redraw of exactly those bounds is dropped by the same check.

Take the canvas out of overlay mode instead. A non-overlay scrollbar is laid out beside the canvas, so that strip is never damaged, and the column count already accounts for its width. The trade-off is a permanently visible scrollbar, so it is a preference — "Persistent vertical scrollbar" — on by default, and applied to open terminals the moment it is toggled rather than on the next launch.

The checkbox is offered only where it would do something, and the page works that out by asking SWT rather than by testing the OS: a throwaway scrollable must report overlay scrollbars, and must still report them gone after a setScrollbarsMode(SWT.NONE). That keeps the preference hidden on Windows and macOS, where that call is an empty method, and in a GTK session run with GTK_OVERLAY_SCROLLING=0, where the artifact cannot arise.

The stock Eclipse Terminal shows the same artifact; the underlying bug is SWT's.