### PR TITLE
Add Find in Conversation

### DIFF
--- a/com.anthropic.claudecode.eclipse/plugin.xml
+++ b/com.anthropic.claudecode.eclipse/plugin.xml
@@ -86,6 +86,11 @@
             name="Dismiss Claude Card"
             description="Dismiss the permission, question or diff-review card awaiting an answer"
             categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
+      <command
+            id="com.anthropic.claudecode.eclipse.commands.findInConversation"
+            name="Find in Conversation"
+            description="Search the active Claude Code conversation"
+            categoryId="com.anthropic.claudecode.eclipse.commands.category"/>
    </extension>
 
    <!-- Active only while a card is awaiting an answer, so the binding below cannot
@@ -96,6 +101,16 @@
             id="com.anthropic.claudecode.eclipse.contexts.cardOpen"
             name="Claude Card Open"
             description="A Claude permission, question or diff-review card is awaiting an answer"
+            parentId="org.eclipse.ui.contexts.window"/>
+      <!-- Active only while the Claude Code view's browser control has keyboard focus —
+           activated/deactivated by a FocusListener in ClaudeGuiView, the same
+           activate/deactivate shape as contexts.cardOpen, just keyed to widget focus
+           instead of card state. Scoping the binding below to this context is what
+           keeps it from taking Ctrl+F away from every editor in the IDE. -->
+      <context
+            id="com.anthropic.claudecode.eclipse.contexts.guiViewFocus"
+            name="Claude Code View Focus"
+            description="The Claude Code view has keyboard focus"
             parentId="org.eclipse.ui.contexts.window"/>
    </extension>
 
@@ -122,6 +137,9 @@
       <handler
             commandId="com.anthropic.claudecode.eclipse.commands.dismissCard"
             class="com.anthropic.claudecode.eclipse.ui.handlers.DismissCardHandler"/>
+      <handler
+            commandId="com.anthropic.claudecode.eclipse.commands.findInConversation"
+            class="com.anthropic.claudecode.eclipse.ui.handlers.FindInConversationHandler"/>
    </extension>
 
    <!-- Key Bindings -->
@@ -159,6 +177,21 @@
             schemeId="org.eclipse.ui.emacsAcceleratorConfiguration"
             contextId="com.anthropic.claudecode.eclipse.contexts.cardOpen"
             sequence="CTRL+G"/>
+      <!-- Default binding for a new command, so it shows up (and is rebindable) under
+           Preferences > Keys like any other Eclipse action. Scoped to guiViewFocus so
+           it never shadows Ctrl+F elsewhere in the IDE (e.g. text editors). Declared
+           only under the default scheme — unlike dismissCard above, this needs no
+           separate Emacs entry: emacsAcceleratorConfiguration's parentId is the default
+           scheme (see org.eclipse.ui's own plugin.xml), and Emacs defines nothing of
+           its own for the guiViewFocus context, so it inherits this binding as-is.
+           dismissCard needed the split only because Escape itself is claimed by Emacs
+           at a broader scope (textEditorScope's multi-stroke prefix), not because of
+           anything about inheritance. -->
+      <key
+            commandId="com.anthropic.claudecode.eclipse.commands.findInConversation"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            contextId="com.anthropic.claudecode.eclipse.contexts.guiViewFocus"
+            sequence="M1+F"/>
    </extension>
 
    <!-- Menus and Toolbar -->

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/claudegui.html
@@ -64,6 +64,18 @@
     <div id="teleport-progress"></div>
   </div>
 
+  <!-- Find-in-conversation bar. One shared DOM instance (only the active tab's pane is
+       ever visible) but its state — query, matches, current index, open/closed — is
+       per-tab; see find.js. Toggled by Ctrl+F (ClaudeGuiView#toggleFindInConversation)
+       and dismissed by Escape via the usual registerOverlayCancel/cardOpen key context. -->
+  <div id="find-bar">
+    <input id="find-input" type="text" placeholder="Find in conversation…" oninput="onFindInput()" onkeydown="onFindKeydown(event)">
+    <span id="find-count"></span>
+    <span class="find-action" id="find-prev" title="Previous match" onclick="findStep(-1)">__CHEVRONUP__</span>
+    <span class="find-action" id="find-next" title="Next match" onclick="findStep(1)">__CHEVRONDOWN__</span>
+    <span class="find-action" id="find-close" title="Close" onclick="closeFindBar()">__X__</span>
+  </div>
+
   <!-- Composer -->
   <div id="composer">
     <!-- Shown when new content streams in below while the user has scrolled up to read
@@ -187,6 +199,7 @@
 <script src="scripts/tabs.js"></script>
 <script src="scripts/supertabs.js"></script>
 <script src="scripts/chat.js"></script>
+<script src="scripts/find.js"></script>
 <script src="scripts/stream.js"></script>
 <script src="scripts/carddock.js"></script>
 <script src="scripts/contextmenu.js"></script>

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/carddock.js
@@ -80,7 +80,72 @@ function clearBottomCard(owner) {
    advertise the truth instead of hardcoding "Esc". Empty means nothing is bound — the
    card then shows no hint at all rather than naming a key that does nothing. */
 let cancelHint = 'Esc';
+/* A STACK, not a single slot: opening the find bar over an already-open history panel
+   (or any overlay-over-overlay combination — nine call sites register here) used to
+   clobber whichever registration was already live, with no way back to it. Dismissing
+   the newer one then left the dismiss key dead for the older one still visibly open,
+   since its registration had been overwritten rather than preserved underneath. Each
+   entry is {fn, isBottom, owner, notifiesJava} — see registerCardCancel for what owner
+   means, and registerOverlayCancel for notifiesJava (whether popping this entry down to
+   an empty stack should call _overlayOpen(false); Java-raised cards never should, since
+   Java already toggled its own context around them and was never told they opened via
+   _overlayOpen in the first place).
+   activeCardCancel/activeCancelIsBottom/activeCancelOwner are kept as mirrors of the TOP
+   entry (see syncTop) so every existing external read (find.js, ui.js) keeps working
+   unchanged: an empty stack mirrors to null/false/null, exactly like the old "nothing
+   registered" state. */
+const overlayStack = [];
 let activeCardCancel = null, activeCancelIsBottom = false, activeCancelOwner = null;
+// How many entries currently on the stack were registered via registerOverlayCancel
+// (notifiesJava: true) rather than registerCardCancel (false) — see registerOverlayCancel
+// for why _overlayOpen must fire on THIS count's 0↔1 transitions, not the stack's own
+// emptiness: a Java-raised card can push/pop while an overlay entry sits underneath it,
+// and none of that may touch _overlayOpen at all. Recomputed by a full reduce() inside
+// pushOverlay/popOverlay (the only two mutators) after every push/pop — the stack is
+// only ever 1-3 entries deep, so this is not worth doing incrementally — so every
+// register/unregister call site, including cancelActiveCard's own pop, gets the correct
+// notify for free.
+let notifyingCount = 0;
+function syncTop() {
+  const top = overlayStack.length ? overlayStack[overlayStack.length - 1] : null;
+  activeCardCancel = top ? top.fn : null;
+  activeCancelIsBottom = top ? top.isBottom : false;
+  activeCancelOwner = top ? top.owner : null;
+}
+/* Pushes fn, or moves it to the top if already present (re-registering the SAME overlay
+   that's already on the stack must not create a second entry for it; if it re-registers
+   with a DIFFERENT notifiesJava than before, the recount below still ends up correct
+   either way). */
+function pushOverlay(fn, isBottom, owner, notifiesJava) {
+  const i = overlayStack.findIndex(e => e.fn === fn);
+  if (i !== -1) overlayStack.splice(i, 1);
+  overlayStack.push({ fn, isBottom: !!isBottom, owner: owner || null, notifiesJava: !!notifiesJava });
+  syncTop();
+  const before = notifyingCount;
+  notifyingCount = overlayStack.reduce((n, e) => n + (e.notifiesJava ? 1 : 0), 0);
+  if (before === 0 && notifyingCount > 0 && window._overlayOpen) window._overlayOpen(true);
+}
+/* Removes fn wherever it sits in the stack, or the top entry if fn is omitted (every
+   bare unregister*() call site — see their own comments for why popping the top is
+   correct there: each only ever runs as a REGISTERED cancel actually firing, so it can
+   only be at the top by the time it runs, or as its owning overlay's own close path with
+   nothing else having registered since). Explicit-fn removal exists for the one case
+   that isn't top-only: ui.js's closeMenus() can close the history panel out from under a
+   LATER overlay (find opened on top of history, then the user clicked outside) — the
+   panel is gone but its entry would otherwise be stranded underneath find's, and the
+   next dismiss-key press would pop find correctly only to land on history's now-dead
+   entry next, consuming a second press on nothing. */
+function popOverlay(fn) {
+  if (!overlayStack.length) return null;
+  const i = fn ? overlayStack.findIndex(e => e.fn === fn) : overlayStack.length - 1;
+  if (i === -1) return null;   // fn wasn't on the stack — e.g. it already removed itself
+  const [entry] = overlayStack.splice(i, 1);
+  syncTop();
+  const before = notifyingCount;
+  notifyingCount = overlayStack.reduce((n, e) => n + (e.notifiesJava ? 1 : 0), 0);
+  if (before > 0 && notifyingCount === 0 && window._overlayOpen) window._overlayOpen(false);
+  return entry;
+}
 
 /* Every hint on screen repaints itself when the binding changes, rather than waiting to be
    rebuilt. Java pushes a new label the moment Eclipse's BindingManager fires — switching
@@ -112,30 +177,43 @@ function cancelKeyName() { return cancelHint; }
 function cancelHintText() { return cancelHint ? cancelHint + ' to cancel' : ''; }
 
 /* Java-raised blocking cards: Java already activated the key context around its own
-   future.get(), so these must NOT notify it again. owner is the tab this card belongs
-   to (the same owner showBottomCard was given) — activeCardCancel is still ONE global
-   slot, so without it a card raised on a background tab would leave its cancel() as
-   the one that fires when the dismiss key is pressed over a DIFFERENT tab's own card. */
-function registerCardCancel(fn, owner) { activeCardCancel = fn; activeCancelIsBottom = true; activeCancelOwner = owner; }
-function unregisterCardCancel() { activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null; }
+   future.get(), so these must NOT notify it again (see registerOverlayCancel for the
+   ones that must — pushOverlay/popOverlay's own notifyingCount bookkeeping is what keeps
+   these two silent while that's still true no matter what else is on the stack). owner
+   is the tab this card belongs to (the same owner showBottomCard was given) — needed
+   even with a stack, since a card raised on a background tab must never be the one that
+   fires when the dismiss key is pressed over a DIFFERENT tab's own card
+   (cancelActiveCard's owner check is what actually enforces that; owner is only carried
+   here for it to read off the top entry). */
+function registerCardCancel(fn, owner) { pushOverlay(fn, true, owner, false); }
+function unregisterCardCancel() { popOverlay(); }
 
-/* Page-local overlays (advisor card, rewind picker, lightbox). Java cannot know these are
-   open — nothing on its side raised them — so the page has to say so, or the key context
-   never activates and the key stays dead however honest the hint is. _overlayOpen is
-   edge-triggered on the Java side, so a missed unregister can only ever be one deep and the
-   next register/unregister corrects it. owner: see registerCardCancel — only meaningful
-   when isBottomCard, since a non-bottom overlay isn't tab-owned. */
-function registerOverlayCancel(fn, isBottomCard, owner) {
-  activeCardCancel = fn; activeCancelIsBottom = !!isBottomCard; activeCancelOwner = owner || null;
-  if (window._overlayOpen) window._overlayOpen(true);
-}
-function unregisterOverlayCancel() {
-  activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null;
-  if (window._overlayOpen) window._overlayOpen(false);
-}
+/* Page-local overlays (advisor card, rewind picker, lightbox, find bar, history panel).
+   Java cannot know these are open — nothing on its side raised them — so the page has to
+   say so, or the key context never activates and the key stays dead however honest the
+   hint is. owner: see registerCardCancel — only meaningful when isBottomCard, since a
+   non-bottom overlay isn't tab-owned. fn on unregister: see popOverlay's own comment —
+   omit it to pop the top (the common case, valid whenever this call IS a registered
+   cancel actually firing), pass it to remove a specific entry that may no longer be on
+   top (e.g. ui.js's closeMenus() closing the history panel while a later overlay sits
+   above it). */
+function registerOverlayCancel(fn, isBottomCard, owner) { pushOverlay(fn, isBottomCard, owner, true); }
+function unregisterOverlayCancel(fn) { popOverlay(fn); }
 
+// One dismiss GESTURE (one Ctrl+G / Esc press) must cancel at most one overlay. The old
+// single-slot design got this for free by accident: a double-fire of the Eclipse command
+// (see DismissCardHandler's own comment — tolerated as a known, harmless quirk) found
+// activeCardCancel already null on its second call and no-opped. The stack has no such
+// accidental protection — a second call within the same gesture finds a NEW top entry
+// (whatever was underneath the first) and cancels that too, observed as one Ctrl+G
+// closing both the find bar AND the history panel underneath it. lastCancelAt makes the
+// one-gesture-one-cancel invariant explicit instead of relying on a side effect that no
+// longer holds. 50ms comfortably covers the ~24ms gap measured between the two calls in
+// /tmp/find-debug.log while staying far below a human's fastest deliberate double-press.
+let lastCancelAt = 0;
 window.cancelActiveCard = function() {
   if (!activeCardCancel) return;
+  if (Date.now() - lastCancelAt < 50) return;
   // Bottom cards only: one parked on a background tab must not vanish because a key was
   // pressed over another conversation. Mirrors renderBottomCard's own visibility test,
   // now split into two checks since each tab tracks its own pendingCard instead of one
@@ -143,13 +221,20 @@ window.cancelActiveCard = function() {
   // showing, AND it must be the same tab that registered this cancel — two different
   // background tabs can each have their own card pending, so "some card is showing" is
   // not enough on its own; it has to be THIS card's owner specifically, or switching to
-  // tab A while activeCardCancel is still tab B's would fire B's cancel from A's screen.
+  // tab A while the top entry is still tab B's would fire B's cancel from A's screen.
   // Overlays (rewind, lightbox) are not tab-owned, so the test does not apply to them.
+  // Reads the TOP entry's own isBottom/owner (the mirrors), so this guard is always
+  // evaluated against whichever overlay would actually be cancelled below, not some
+  // other entry buried in the stack.
   const t = activeTab();
   if (activeCancelIsBottom && (!t || !t.pendingCard || activeCancelOwner !== t)) return;
-  const fn = activeCardCancel;
-  activeCardCancel = null; activeCancelIsBottom = false; activeCancelOwner = null;
-  fn();
+  const entry = popOverlay();   // notifyingCount bookkeeping (and _overlayOpen) handled inside
+  if (!entry) return;
+  // Written here, not at function entry: an early return above (nothing registered, the
+  // bottom-card visibility guard, popOverlay finding nothing) must not arm the guard for
+  // a call that didn't actually cancel anything.
+  lastCancelAt = Date.now();
+  entry.fn();
 };
 
 /* ---- server-side card teardown ----

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -72,7 +72,17 @@ const jumpToLatestEl = document.getElementById('jump-to-latest');
 function updateJumpToLatest() {
   if (jumpToLatestEl) jumpToLatestEl.classList.toggle('show', scrollLocked && !followTail);
 }
-messagesEl.addEventListener('scroll', () => { followTail = isNearBottom(); updateJumpToLatest(); });
+// Set by find.js immediately before a programmatic scrollIntoView (jumping to a search
+// match) and cleared right after: the 'scroll' event this fires is asynchronous relative
+// to the call that caused it, so a plain "set followTail then restore it" in find.js
+// would race this listener — it could run AFTER the restore and clobber followTail back
+// to isNearBottom()'s value. Checking a flag the listener itself respects is the only
+// race-free way to except one particular scroll from recomputing followTail.
+let suppressFollowTailUpdate = false;
+messagesEl.addEventListener('scroll', () => {
+  if (suppressFollowTailUpdate) return;
+  followTail = isNearBottom(); updateJumpToLatest();
+});
 /* The one place the transcript decides whether to move. Shared with showWorking, which
    appends outside of scrollBottom. */
 function autoScroll() {
@@ -284,6 +294,9 @@ function toolLabel(name) {
  * @param {string} name  raw tool name (mcp__… prefixes get stripped for display)
  * @param {Object} input tool_use input (file_path/command/pattern/… picked for detail)
  * @param {"done"|"interrupted"|undefined} [status] reload path only — colors the dot
+ * @param {string} [errorText] reload path only
+ * @param {string} [root] the OWNING conversation's working directory, for resolving a
+ *   relative file_path when the line is clicked — see .tpath's onclick below.
  * @returns {HTMLElement} the .tool-line item
  */
 /* Outcome text for an ExitPlanMode line. Shared by the LIVE decision path
@@ -304,7 +317,7 @@ function setToolError(line, text) {
   if (!sub) { sub = document.createElement('div'); sub.className = 'tool-sub err'; line.appendChild(sub); }
   sub.textContent = '⚠ ' + text;
 }
-function makeToolLine(name, input, status, errorText) {
+function makeToolLine(name, input, status, errorText, root) {
   input = input || {};
   const path = input.file_path || input.path || input.notebook_path || '';
   const detail = path || input.command || input.pattern || input.query || input.url || input.prompt || '';
@@ -312,7 +325,21 @@ function makeToolLine(name, input, status, errorText) {
   const dotClass = status === 'done' ? 'dot done' : status === 'interrupted' ? 'dot red' : 'dot';
   line.innerHTML = '<span class="' + dotClass + '"></span><span class="tname"></span> <span class="tpath"></span>';
   line.querySelector('.tname').textContent = toolLabel(name);   // generic label, not the raw name
-  line.querySelector('.tpath').textContent = detail;
+  const tpathEl = line.querySelector('.tpath');
+  tpathEl.textContent = detail;
+  // Only an actual file path is clickable — never the bash/grep/url/prompt fallbacks
+  // `detail` also covers. Silently a no-op if the path turns out stale (deleted,
+  // renamed) or unresolvable; see ClaudeGuiView#openFileInEditor.
+  if (path && window._openFileInEditor) {
+    tpathEl.classList.add('clickable');
+    tpathEl.title = 'Open in editor';
+    // No stopPropagation: unlike msgactions.js's icons (which sit inside a clickable
+    // .item), no ancestor of .tool-line has its own onclick, and this transcript sits
+    // inside the same page as menus tracked by openMenuEl — stopping propagation here
+    // would silently stop clicking a path from also closing an open menu via ui.js's
+    // click-outside handler, same class of bug as cycleSearchScope's innerHTML swap.
+    tpathEl.onclick = () => window._openFileInEditor(path, root || rootPathOf(activeTab()));
+  }
   const diff = buildToolDiff(name, input);
   if (diff) {
     const sub = document.createElement('div'); sub.className = 'tool-sub'; sub.textContent = diff.summary;
@@ -337,7 +364,9 @@ function addToolLine(payload) {
   if (!ensureTurn()) return;
   markToolsDone(curTurn);   // a new tool starting means the previous one finished → green
   let info; try { info = JSON.parse(payload); } catch (e) { info = { name: payload, input: {} }; }
-  const line = makeToolLine(info.name || 'tool', info.input || {});
+  // rtab, not activeTab(): a background tab's own stream must resolve a relative
+  // file_path against ITS OWN root, not whichever tab happens to be on screen.
+  const line = makeToolLine(info.name || 'tool', info.input || {}, undefined, undefined, rootPathOf(rtab));
   // The tool_use id, so this line can be found again when its result lands. An
   // older core sends no id — the line then just keeps the inferred green dot.
   if (info.id) line.dataset.tuid = info.id;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/find.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/find.js
@@ -1,0 +1,696 @@
+/* find.js — Find-in-conversation: a per-tab find bar over the active tab's own .pane.
+   Ctrl+F (rebindable) is wired through ClaudeGuiView#toggleFindInConversation, which
+   calls window.toggleFindBar(); Escape closes it via the usual registerOverlayCancel
+   path, same as every other page-local overlay (History, the model picker, …).
+
+   Matches are painted with the CSS Custom Highlight API (CSS.highlights) rather than by
+   wrapping matched text in <mark> elements: a wrapped-node approach would mean rebuilding
+   the matched text nodes on every keystroke, which risks corrupting markdown-rendered
+   markup (inline code, links, bold) and can clobber a live streaming turn's own DOM
+   mutations. Highlights paint Ranges without touching the DOM at all, so re-searching is
+   just "throw away the old Ranges and build new ones" with nothing to undo.
+
+   Design: only what's on screen is ever highlighted, and it follows the scroll position
+   live. A long conversation made typing in the find box scan every text node in the whole
+   transcript on every keystroke, and held a live Range for every match found anywhere —
+   both costs scale with conversation length and match count instead of with what's
+   actually useful to look at. Since the user only cares about matches near what they're
+   currently reading, every re-highlight (typing, scrolling, stepping) only ever touches
+   the `.turn`s intersecting the viewport — bounded by screen size, not conversation
+   length or match density. There is deliberately no "N of M" count: with no fixed search
+   window, there both isn't a stable "M" to report and it invites reading a viewport-
+   relative position as if it were the match's place in the whole conversation.
+
+   Enter/Shift+Enter still search the WHOLE document for the next/previous match, same as
+   a browser's own Ctrl+F — they just don't pre-collect the whole document's matches to do
+   it: nextMatch walks outward turn-by-turn (see turnSibling) from wherever the active
+   match is (or the near/far edge of the viewport, if none is active yet) until it finds
+   one, bounded by how far away that match actually is rather than by conversation length.
+   Typing can also jump the view, via the same probe: if what you just typed has no match
+   on screen but does exist elsewhere, reHighlight shows it immediately (goToMatch) rather
+   than making you press Enter to find out — but only the first time per query, so editing
+   a query whose match is already off-screen doesn't re-jump the view on every keystroke.
+
+   State (query, active match, open/closed) is per-tab, parked/restored by
+   onFindTabSwitch — called from tabs.js#switchTab exactly like the composer draft. */
+
+const FIND_MATCH_HL = 'cc-find-match';
+const FIND_ACTIVE_HL = 'cc-find-active';
+const HAS_HIGHLIGHT_API = typeof CSS !== 'undefined' && !!CSS.highlights && typeof Highlight !== 'undefined';
+// Last Highlight object painted under each key. CSS.highlights.set() does not reliably
+// REPLACE an existing registration under WebKitGTK — clearing the OBJECT itself (a
+// `Highlight` is Set-like) before delete()/set() below is a second, independent way to
+// make old ranges disappear that doesn't depend on the registry-level calls alone.
+let lastMatchHl = null, lastActiveHl = null;
+
+// onFindInput's debounce timer — module-level (not per-tab) since only one find bar is
+// ever open/focused at a time. Cleared on tab switch and bar close so a keystroke typed
+// just before either can't fire afterward against the wrong tab or a closed bar.
+let findInputDebounce = null;
+// Scroll re-highlight's own debounce timer, same reasoning — scroll fires far more often
+// than is useful to react to.
+let findScrollDebounce = null;
+// The element currently wired with the scroll listener below, so it can be removed
+// again on close/tab-switch rather than accumulating one listener per open.
+let findScrollTarget = null;
+
+/** @typedef {Object} FindState
+ * @property {boolean} open
+ * @property {string} query
+ * @property {?Range} active the current Enter/Shift+Enter target, or null if none — the
+ *   only match tracked by index/position; everything else visible is just "highlighted",
+ *   not addressable, since the viewport set is rebuilt from scratch on every recompute.
+ */
+/** @param {Tab} tab @returns {FindState} */
+function findStateOf(tab) {
+  if (!tab.findState) tab.findState = { open: false, query: '', active: null };
+  return tab.findState;
+}
+
+/** Called from tabs.js#switchTab before the pane swap. Highlights are global (painted
+ *  by name, not scoped to a pane), so the outgoing tab's matches must be cleared even
+ *  though its pane is just hidden, not destroyed — otherwise they'd still show through
+ *  on top of the newly-active pane at the same viewport coordinates. */
+function onFindTabSwitch(prevTab, nextTab) {
+  // A pending debounced re-highlight (see onFindInput/onFindScroll) closes
+  // over activeTab() at the time it FIRES, not when it was scheduled — left alone,
+  // switching tabs within the debounce window would fire it against the newly-active
+  // tab, overwriting that tab's own query/highlights with the outgoing tab's.
+  clearTimeout(findInputDebounce);
+  clearTimeout(findScrollDebounce);
+  detachFindScroll();
+  // Unconditional, not gated on prevTab existing: CSS.highlights is document-global
+  // state, not tied to any one pane, so "clear, then repaint whatever the incoming
+  // tab has" is the only invariant that's correct in every case — including closing
+  // the active tab, where switchTab's prev lookup comes back null because the tab
+  // was already spliced out before this runs.
+  clearHighlights();
+  // The bar's cancel-stack entry belongs to whichever tab had it open, not to the bar
+  // element itself — switching away from a tab whose bar was open must pop that entry
+  // (otherwise it's stranded: Eclipse still reports the dismiss key as bound to a card
+  // that isn't visible, and the actual top of the stack eats the keypress instead), and
+  // switching TO a tab whose bar is open must push a fresh one. Gated on the open state
+  // actually changing (not "prevTab != nextTab") because both tabs can have the bar open
+  // at once — a blind unregister+register there would fire cardClosed()/cardOpened() back
+  // to back for no visible change, which is exactly the context-activation churn the
+  // toolbar-jump bug is suspected to come from. See carddock.js's pushOverlay/popOverlay.
+  // Unconditional unregister (not gated on prevOpen) rather than a symmetric
+  // prevOpen/nextOpen diff: closing the active tab splices it out before this runs, so
+  // prevTab comes back null and prevOpen reads false even when ITS bar was open (see the
+  // clearHighlights comment above) — a diff would miss exactly that case. popOverlay is
+  // safe to call speculatively: with nothing registered it just logs a MISS and returns,
+  // touching neither the stack nor notifyingCount.
+  const nextOpen = nextTab ? findStateOf(nextTab).open : false;
+  if (!nextOpen) unregisterOverlayCancel(closeFindBar);
+  else {
+    const prevOpen = prevTab ? findStateOf(prevTab).open : false;
+    if (!prevOpen) registerOverlayCancel(closeFindBar, false);
+  }
+  const bar = document.getElementById('find-bar');
+  if (!nextTab) { if (bar) bar.classList.remove('open'); return; }
+  const st = findStateOf(nextTab);
+  if (bar) {
+    bar.classList.toggle('open', st.open);
+    // See openFindBar's matching comment: chrome-row visibility (the update banner,
+    // collapsed root row, …) can have changed since this bar last computed its offset,
+    // so a tab switch that re-shows it needs a fresh one too, not just openFindBar.
+    if (st.open) bar.style.top = (messagesEl.offsetTop + 8) + 'px';
+  }
+  if (st.open) {
+    document.getElementById('find-input').value = st.query;
+    attachFindScroll();
+    // This runs BEFORE tabs.js#switchTab swaps pane.style.display — the incoming pane
+    // is still display:none here, so every turn's getBoundingClientRect() would come
+    // back 0,0 and reHighlight would (wrongly) paint nothing. Defer one frame, by which
+    // point the swap (a synchronous style write, not itself async) has already applied.
+    requestAnimationFrame(() => { if (activeTab() === nextTab) reHighlight(nextTab, false); });
+  }
+}
+
+window.toggleFindBar = function() {
+  const tab = activeTab();
+  if (!tab) return;
+  const st = findStateOf(tab);
+  if (st.open) closeFindBar(); else openFindBar();
+};
+
+function openFindBar() {
+  const tab = activeTab();
+  if (!tab) return;
+  const st = findStateOf(tab);
+  st.open = true;
+  const bar = document.getElementById('find-bar');
+  // #find-bar is positioned against #zoom-root (chat.css), whose top edge is the very
+  // top of the page — ABOVE #supertab-row/#cwd-row/#toolbar/#update-banner, not the top
+  // of the transcript. A fixed CSS `top` therefore floats the bar over whichever of
+  // those chrome rows happens to be visible instead of over #messages, covering the tab
+  // strip (confirmed by screenshot: the bar sat over the first tab). messagesEl.offsetTop
+  // is #messages' actual distance from that same origin, so this clears every combination
+  // of shown/hidden chrome rows without hardcoding any of their heights.
+  bar.style.top = (messagesEl.offsetTop + 8) + 'px';
+  bar.classList.add('open');
+  const inp = document.getElementById('find-input');
+  inp.value = st.query;
+  registerOverlayCancel(closeFindBar, false);
+  setTimeout(() => { inp.focus(); inp.select(); }, 0);
+  attachFindScroll();
+  if (st.query) reHighlight(tab, true);
+}
+function closeFindBar() {
+  const tab = activeTab();
+  const bar = document.getElementById('find-bar');
+  // A keystroke or scroll just before Escape could otherwise fire after this, repainting
+  // highlights for a bar the user just closed.
+  clearTimeout(findInputDebounce);
+  clearTimeout(findScrollDebounce);
+  detachFindScroll();
+  if (bar) bar.classList.remove('open');
+  if (tab) {
+    const st = findStateOf(tab);
+    st.open = false;
+    st.active = null;
+  }
+  clearHighlights();
+  // A stale "Not found" from this session would otherwise still be on screen the next
+  // time the bar opens, before anything has re-run to clear it.
+  updateFindCount(null);
+  // Removes closeFindBar's entry BY IDENTITY (see ui.js's own history-panel close for
+  // the same pattern) rather than popping the top of carddock.js's cancel stack: another
+  // overlay/card can have registered on top of this bar's entry since it opened, and a
+  // bare unregister here would pop THAT one instead, leaving this bar's own entry
+  // stranded in the stack to consume a future dismiss-key press for nothing.
+  unregisterOverlayCancel(closeFindBar);
+  // Give focus back to the composer — closing a find bar shouldn't strand keyboard
+  // focus on a control that just disappeared.
+  if (typeof input !== 'undefined' && input) input.focus();
+}
+
+/** Wires the viewport scroll listener for the active tab's pane, so manually scrolling
+ *  while the bar is open re-highlights to match without needing Enter/typing. Attached
+ *  fresh on open/tab-switch and explicitly removed on close/tab-switch (detachFindScroll)
+ *  rather than left to accumulate — messagesEl outlives any one tab or find session. */
+function attachFindScroll() {
+  detachFindScroll();
+  findScrollTarget = messagesEl;
+  findScrollTarget.addEventListener('scroll', onFindScroll, { passive: true });
+}
+function detachFindScroll() {
+  if (findScrollTarget) findScrollTarget.removeEventListener('scroll', onFindScroll);
+  findScrollTarget = null;
+}
+function onFindScroll() {
+  // scrollToMatch's own scrollIntoView sets this flag for exactly this reason: Enter/
+  // Shift+Enter already recompute the viewport highlight themselves right after moving
+  // it, so reacting to the scroll THEY caused would just redo the same work a frame
+  // later — or worse, race it, since suppressFollowTailUpdate's own reset also happens
+  // on the next frame.
+  if (typeof suppressFollowTailUpdate !== 'undefined' && suppressFollowTailUpdate) return;
+  const tab = activeTab();
+  if (!tab || !findStateOf(tab).open) return;
+  clearTimeout(findScrollDebounce);
+  // A MANUAL scroll means the user just told you where they want to look. reHighlight
+  // itself drops st.active whenever it's no longer on screen (see its own comment) — if
+  // the previously active match scrolled out of view, keeping it "active" would make the
+  // next Enter/Shift+Enter resume from that old, no-longer-visible position instead of
+  // from where the user is now, which read as "the arrows seem to do nothing" when the
+  // jump landed somewhere the user wasn't looking.
+  findScrollDebounce = setTimeout(() => {
+    reHighlight(tab, false);
+  }, 100);
+}
+
+/** True if any of `range`'s client rects intersects messagesEl's visible viewport, both
+ *  vertically and horizontally (see matchesInViewport's comment on why horizontal matters
+ *  too: a wide code block can scroll a match out of view sideways while it's still
+ *  vertically within messagesEl's bounds). */
+function rangeIntersectsViewport(range) {
+  if (!range.startContainer || !range.startContainer.isConnected) return false;
+  const box = messagesEl.getBoundingClientRect();
+  for (const r of range.getClientRects()) {
+    if (r.bottom >= box.top && r.top <= box.bottom && r.right >= box.left && r.left <= box.right) return true;
+  }
+  return false;
+}
+
+function onFindInput() {
+  const tab = activeTab();
+  if (!tab) return;
+  clearTimeout(findInputDebounce);
+  const value = document.getElementById('find-input').value;
+  findInputDebounce = setTimeout(() => {
+    const st = findStateOf(tab);
+    st.query = value;
+    // st.active is deliberately left alone here — reHighlight decides whether it still
+    // matches the new query (activeStillMatches) and invalidates it itself if not. Typing
+    // progressively over the same word (e.g. "qui" → "quilt") should hold the view still,
+    // not treat every keystroke as a brand new search that forgets where you just were.
+    reHighlight(tab, true);   // recomputes #find-count too — see its own docstring
+  }, 120);
+}
+function onFindKeydown(e) {
+  if (e.key === 'Enter') { e.preventDefault(); findStep(e.shiftKey ? -1 : 1); }
+}
+
+// A 1-2 character query against a long conversation routinely matches by the
+// thousands — noisy to look at and expensive to search for a query too short to mean
+// anything specific yet. Below this, the bar just doesn't search: highlights clear.
+const FIND_MIN_QUERY_LEN = 3;
+
+/** Recomputes and paints highlights for every match within the current viewport, and
+ *  updates the "Not found" indicator. Normally passive — doesn't move the view — EXCEPT
+ *  when `allowJump` is true, the viewport is empty, and nothing is active yet (see
+ *  below), the one case where this jumps the view on its own.
+ *
+ *  `allowJump` must be false for any call triggered BY a scroll (onFindScroll) or by a
+ *  tab becoming visible again (onFindTabSwitch) — the user just told you where they want
+ *  to be by scrolling/switching there, so auto-centering on an off-screen match would
+ *  yank the view right back. It's true only for calls triggered by typing (onFindInput)
+ *  or opening the bar fresh (openFindBar), where there's no existing scroll position to
+ *  respect yet and jumping to the match is the whole point.
+ *
+ *  An empty viewport does NOT by itself mean an empty conversation — the query may
+ *  simply match somewhere off-screen — so when the viewport comes up empty this also
+ *  probes forward and backward from it (nextMatch with no starting point) before
+ *  declaring "Not found". That probe is cheap on the common case (a match is usually
+ *  nearby: it stops at the first turn that has one) and only walks the full document on
+ *  a genuine miss — which is exactly when the user needs to be told there's nothing.
+ *  This probe (and the "Not found" it can produce) only runs when allowJump is true —
+ *  a scroll- or tab-switch-triggered call that lands on an empty viewport just clears
+ *  the highlight and leaves the message alone, since it isn't asking "does this exist".
+ *
+ *  If the probe finds something, it's shown immediately via goToMatch rather than left
+ *  off-screen for the user to go hunt for with Enter — but ONLY once st.active no longer
+ *  satisfies the CURRENT query (see activeStillMatches): typing progressively over the
+ *  same word ("qui" → "quilt") keeps the view exactly where it was, since the match
+ *  you're already looking at is still a hit; editing to something that match no longer
+ *  contains invalidates it and re-probes, same as if nothing had been found yet. */
+function reHighlight(tab, allowJump) {
+  const st = findStateOf(tab);
+  if (!st.query || st.query.length < FIND_MIN_QUERY_LEN) {
+    clearHighlights();
+    updateFindCount(null);
+    return;
+  }
+  const needle = st.query.toLowerCase();
+  // Validate st.active against the CURRENT query before doing anything else with it — a
+  // stale active match (text edited so it no longer satisfies the query) must not be
+  // passed to paintHighlights as "active" just because the viewport happens to have
+  // OTHER matches of the new query; it also must not be left to feed a later Enter step.
+  if (st.active) {
+    if (activeStillMatches(st.active, needle)) {
+      // Re-anchor the end: the active Range's length is still the OLD needle's, so a
+      // longer new needle (matched at the same start) would otherwise paint a highlight
+      // shorter than the actual match. Safe without a bounds check — activeStillMatches
+      // only returns true when the whole needle already fits from this start position.
+      st.active.setEnd(st.active.startContainer, st.active.startOffset + needle.length);
+    } else {
+      st.active = null;
+    }
+  }
+  // Invariant this whole block maintains: whenever matches are visible, exactly one of
+  // them is active. activeStillMatches only checks the TEXT at st.active's position, not
+  // whether that position is still on screen — an active match can survive editing the
+  // query yet have been scrolled off-screen in the meantime (or, before this check
+  // existed, just never have been on screen to begin with while OTHER matches of the
+  // same query were visible), leaving nothing visibly marked despite a screen full of
+  // highlights. Drop it here too, not just in onFindScroll (which only covers the
+  // scroll-triggered path) — this covers every path through reHighlight uniformly.
+  if (st.active && !rangeIntersectsViewport(st.active)) {
+    st.active = null;
+  }
+  const matches = matchesInViewport(tab.pane, needle);
+  if (matches.length) {
+    // No active match at all (a fresh query, one just invalidated above, or one dropped
+    // by a manual scroll — see onFindScroll): adopt the first VISIBLE one rather than
+    // leaving nothing marked. Safe without an allowJump check unlike goToMatch — this
+    // never scrolls, it only marks a match that's already on screen, so it can't yank
+    // the view like an unconditional jump would. Without this, nothing reads as
+    // "selected" until the user presses an arrow once, which is confusing with a screen
+    // full of identical-looking matches and made Enter/Shift+Enter's very first press
+    // look like it did nothing.
+    if (!st.active) st.active = matches[0];
+    paintHighlights(matches, st.active);
+    updateFindCount(null);
+    return;
+  }
+  // st.active can't be non-null here: the check above already dropped it unless it's
+  // in-viewport, and an in-viewport active match would have made matches.length > 0.
+  if (!allowJump) { paintHighlights([], null); return; }
+  // nextMatch's "no starting point" case begins at the first/last VISIBLE turn — if the
+  // viewport has no turns at all (pane not laid out yet, or scrolled into a gap between
+  // turns), both directions come back null even though matches could exist elsewhere;
+  // fall back to a real document-wide search rather than reporting a false "Not found".
+  const found = turnsInViewport(tab.pane).length
+      ? (nextMatch(tab.pane, null, 1, needle) || nextMatch(tab.pane, null, -1, needle))
+      : firstMatchInDocument(tab.pane, 1, needle);
+  if (found) goToMatch(tab, found); else { paintHighlights([], null); updateFindCount('Not found'); }
+}
+
+/** True if `active` (a Range from an EARLIER, possibly different query) still starts a
+ *  match of the CURRENT `needle` at the same position — i.e. the text hasn't been
+ *  edited away from under it, just possibly extended (typing "qui" then "quilt" moves
+ *  the query forward over the same word without invalidating where it started). Used by
+ *  reHighlight to decide whether to hold the view still or treat the active match as
+ *  stale and re-probe for a new one. */
+function activeStillMatches(active, needle) {
+  if (!active || !active.startContainer || !active.startContainer.isConnected) return false;
+  const text = active.startContainer.textContent.toLowerCase();
+  return text.startsWith(needle, active.startOffset);
+}
+
+/** Moves to `range`: marks it active, scrolls it into view IF IT ISN'T ALREADY (stepping
+ *  to a match that's already comfortably on screen shouldn't re-center the view — that
+ *  would be a visible jolt on every arrow press for no reason, and made the very first
+ *  step from the first visible match look like it did nothing when it re-centered on
+ *  the same spot), then repaints highlights for the new viewport and clears any
+ *  "Not found". Shared by findStep (Enter/Shift+Enter) and reHighlight's off-screen-match
+ *  case (typing revealed a match that wasn't visible yet) — both end up doing exactly
+ *  this once a target match is decided on. */
+function goToMatch(tab, range) {
+  const st = findStateOf(tab);
+  st.active = range;
+  // The user pressing Enter/an arrow to jump to a match is what means they've left the
+  // tail — not merely "we happened to scroll to get there" (see scrollToMatch's own
+  // comment for the rest of this story). Set this here, before the wasVisible branch, so
+  // it applies even when the target was already on screen and scrollToMatch never runs:
+  // without this, landing on an already-visible match left followTail exactly as it was
+  // (often still true from before the search began), so an unrelated autoScroll — a
+  // working-indicator tick, streamed content — could yank the view back to the bottom
+  // even with scroll-lock armed, since that lock only holds when followTail is ALSO false.
+  followTail = false;
+  updateJumpToLatest();
+  const wasVisible = rangeIntersectsViewport(range);
+  if (!wasVisible) {
+    scrollToMatch(range);
+    // scrollToMatch sets suppressFollowTailUpdate, so the scroll it triggers won't also
+    // fire onFindScroll — recompute the viewport highlight here instead, once, now that
+    // the view has (or will have, synchronously for an instant scroll) actually moved.
+  }
+  paintHighlights(matchesInViewport(tab.pane, st.query.toLowerCase()), range);
+  updateFindCount(null);
+}
+
+function findStep(dir) {
+  const tab = activeTab();
+  if (!tab) return;
+  const st = findStateOf(tab);
+  if (!st.query || st.query.length < FIND_MIN_QUERY_LEN) return;
+  const needle = st.query.toLowerCase();
+  // Wrap around at the document's actual start/end, same as a browser's own Ctrl+F —
+  // without this, Enter on the last match would silently do nothing, indistinguishable
+  // from a broken feature since there's no "N of M" count to signal "you're at the end".
+  const next = nextMatch(tab.pane, st.active, dir, needle) || firstMatchInDocument(tab.pane, dir, needle);
+  if (!next) return;   // truly no match anywhere
+  goToMatch(tab, next);
+}
+
+function updateFindCount(text) {
+  const el = document.getElementById('find-count');
+  if (el) el.textContent = text || '';
+}
+
+/** The direct `.turn` children of `pane` that intersect messagesEl's visible viewport,
+ *  in document order. Shared by matchesInViewport (what to highlight) and nextMatch's
+ *  "start from the top of the viewport" case (Enter with no active match yet). */
+function turnsInViewport(pane) {
+  const box = messagesEl.getBoundingClientRect();
+  const out = [];
+  for (const t of pane.querySelectorAll(':scope > .turn')) {
+    const r = t.getBoundingClientRect();
+    if (r.bottom >= box.top && r.top <= box.bottom) out.push(t);
+  }
+  return out;
+}
+
+/** The next/previous `.turn` sibling of `turn`, skipping over any non-.turn direct pane
+ *  children (a "Claude is working" indicator in working.js, model-switch dividers in
+ *  models.js/history.js) — callers that walk turn-by-turn need to agree on what a "turn"
+ *  is with turnsInViewport/matchesInTurn's callers, or a sibling walk can silently skip
+ *  or misclassify a non-.turn element. */
+function turnSibling(turn, dir) {
+  let t = turn;
+  do {
+    t = dir < 0 ? t.previousElementSibling : t.nextElementSibling;
+  } while (t && !t.classList.contains('turn'));
+  return t;
+}
+
+/** Case-insensitive match Ranges for `needle` (already lowercased) within the text nodes
+ *  of a single element (one `.turn`), in document order. Deliberately node-local: a match
+ *  split across two adjacent text nodes (e.g. a markdown-rendered <strong> boundary
+ *  sitting mid-word) is missed rather than risking a Range that spans unrelated markup —
+ *  an acceptable, rare miss for a find-as-you-type bar.
+ *
+ *  Does NOT filter out matches inside collapsed/display:none content (a collapsed
+ *  thinking block, a compacted chat's body) — that used to happen here via a trailing
+ *  getClientRects() check on every match, but every caller that cares about visibility
+ *  already does its own getClientRects()-based check afterward (rangeIntersectsViewport
+ *  for the viewport-bound callers, hasAnyRect below for the ones that don't care about
+ *  the viewport but still need to skip invisible matches). Doing it here too meant EVERY
+ *  match paid for layout twice on the hot path (typing/scrolling in a turn with many
+ *  matches) for no benefit — the second check subsumes the first, since an element with
+ *  no rects at all also fails the viewport intersection test. Callers that don't need
+ *  either check (there are none currently, but a future one might) get the small matches
+ *  themselves for free by skipping the extra layout read. */
+function matchesInTurn(turn, needle) {
+  const ranges = [];
+  const walker = document.createTreeWalker(turn, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const tag = node.parentElement && node.parentElement.tagName;
+      return (tag === 'SCRIPT' || tag === 'STYLE') ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+    }
+  });
+  let node;
+  while ((node = walker.nextNode())) {
+    const text = node.textContent.toLowerCase();
+    let from = 0, idx;
+    while ((idx = text.indexOf(needle, from)) !== -1) {
+      const r = new Range();
+      r.setStart(node, idx);
+      r.setEnd(node, idx + needle.length);
+      ranges.push(r);
+      from = idx + needle.length;
+    }
+  }
+  return ranges;
+}
+
+/** True if `r` has any box at all — false for a Range inside collapsed/display:none
+ *  content (a collapsed thinking block, a compacted chat's body). Used by callers that
+ *  need to skip invisible matches but, unlike rangeIntersectsViewport, don't care whether
+ *  the match is actually on screen (nextMatch/firstMatchInDocument can legitimately land
+ *  on a match far outside the viewport — see the file header on why Enter jumps freely). */
+function hasAnyRect(r) {
+  return r.getClientRects().length > 0;
+}
+
+// A screenful can't usefully show more distinct highlighted matches than this regardless
+// of how dense a turn's content is — e.g. a single very long line packed with matches,
+// only a few of which are within the horizontal scroll position actually on screen (see
+// matchesInViewport). Capping the COLLECTED (not just painted) set at a small number
+// bounds the worst case for the live-Range/paint cost this whole design exists to avoid;
+// it does NOT bound the scan cost of finding them (see matchesInViewport's own comment)
+// — that's a different, harder problem (geometry-first pruning) not attempted here. Split
+// per turn, not applied as one global total — see matchesInViewport's own comment on why.
+const FIND_VIEWPORT_MATCH_CAP = 60;
+
+/** All matches within the viewport itself — NOT just within the turns that intersect it.
+ *  A `.turn` is a whole message, and one turn can be far taller than the screen (a large
+ *  tool-output block, e.g. a JSON schema dump, rendered as a single turn): matchesInTurn
+ *  finds every match anywhere in that turn regardless of how much of it is actually
+ *  scrolled into view, so filtering by TURN intersection alone could still collect (and
+ *  paint, as live Ranges) hundreds of matches sitting above/below the visible slice of
+ *  that one turn — the exact live-Range cost this whole design exists to bound. Filtering
+ *  each match's own rect against the viewport, not just its turn's, is what actually
+ *  keeps the live set screen-sized regardless of how a turn's content is laid out.
+ *
+ *  Note what this does NOT bound: matchesInTurn itself still walks and builds a Range for
+ *  EVERY match in a turn that intersects the viewport at all, even ones nowhere near the
+ *  visible slice (a turn far taller, or with a much wider single line, than the screen).
+ *  Each Range then costs one getClientRects() call here to test visibility. If a turn has
+ *  many matches but few are actually visible (e.g. one very long line, most of it
+ *  scrolled out of view horizontally, with dozens of matches packed into it), that scan
+ *  cost is real and unbounded by FIND_VIEWPORT_MATCH_CAP below — the cap only stops
+ *  collecting once enough VISIBLE ones are found, it can't skip the invisible ones without
+ *  measuring them first. Bounding that scan itself would need pruning by position before
+ *  ever calling getClientRects, which is a real redesign; not attempted here. */
+function matchesInViewport(pane, needle) {
+  const turns = turnsInViewport(pane);
+  // Capped PER TURN, not as one global running total that stops the whole scan once hit:
+  // the viewport commonly spans several turns, and a global cap filled entirely by a
+  // dense first turn would paint zero highlights in every turn below it, even where the
+  // user is actually looking. Splitting the budget evenly means a screen with one dense
+  // turn and several sparse ones still lights up everywhere there's a match, just with a
+  // smaller share going to the dense one — a strict global total isn't worth that cost.
+  const perTurnCap = Math.max(8, Math.floor(FIND_VIEWPORT_MATCH_CAP / Math.max(1, turns.length)));
+  const matches = [];
+  for (const t of turns) {
+    let inTurn = 0;
+    for (const m of matchesInTurn(t, needle)) {
+      // rangeIntersectsViewport checks every client rect a match has (it can wrap across
+      // a line break) against BOTH axes — see its own comment on why horizontal bounds
+      // matter here too: a wide code block (e.g. an indented JSON dump) renders inside
+      // its own horizontally-scrolling <pre>, and a match scrolled out of THAT box still
+      // reports its laid-out position in viewport coordinates, which can land far to the
+      // right of messagesEl's own visible width. Without this check such a match passes
+      // a vertical-only test, gets highlighted, and is completely invisible (painted off
+      // to the side) — indistinguishable from "not highlighted at all" to the user, while
+      // Enter/Shift+Enter still find and jump to it.
+      if (rangeIntersectsViewport(m)) {
+        matches.push(m);
+        if (++inTurn >= perTurnCap) break;   // next TURN, not the whole scan — see above
+      }
+    }
+  }
+  return matches;
+}
+
+/** Finds the next (dir>0) or previous (dir<0) match anywhere in the document relative to
+ *  `from` (a Range, normally st.active) — or, if `from` is null, starting at the top of
+ *  the current viewport searching forward (dir>0) or its bottom searching backward
+ *  (dir<0), matching "Enter with nothing active yet starts from what's on screen". Walks
+ *  turn-by-turn (via turnSibling) outward from the starting point, examining the starting
+ *  turn's OWN matches first (filtered to strictly after/before `from` when one is given),
+ *  then whole turns one at a time until a match is found or the document ends — bounded
+ *  by how far away the next match actually is, not by conversation length. */
+function nextMatch(pane, from, dir, needle) {
+  let turn, withinTurn;
+  if (from && from.startContainer && from.startContainer.isConnected) {
+    turn = from.startContainer.parentElement && from.startContainer.parentElement.closest('.turn');
+  }
+  if (turn) {
+    withinTurn = matchesInTurn(turn, needle).filter(r => hasAnyRect(r) &&
+      (dir < 0 ? r.compareBoundaryPoints(Range.START_TO_START, from) < 0
+               : r.compareBoundaryPoints(Range.START_TO_START, from) > 0)
+    );
+  } else {
+    // No active match (or it's gone stale/detached): start from whichever end of the
+    // viewport `dir` searches away from. Filtered to matches actually ON SCREEN in that
+    // turn — not the turn's full match list — since with no prior position to step from,
+    // "the nearest match to what the user is looking at" means visible, not merely inside
+    // whichever turn happens to intersect the viewport (that turn can be far taller than
+    // the screen, e.g. a large code block, with matches above/below the visible slice).
+    const visible = turnsInViewport(pane);
+    turn = dir < 0 ? visible[visible.length - 1] : visible[0];
+    withinTurn = turn ? matchesInTurn(turn, needle).filter(rangeIntersectsViewport) : [];
+  }
+  if (withinTurn.length) return dir < 0 ? withinTurn[withinTurn.length - 1] : withinTurn[0];
+
+  let t = turn;
+  while (t) {
+    t = turnSibling(t, dir);
+    if (!t) return null;
+    const m = matchesInTurn(t, needle).filter(hasAnyRect);
+    if (m.length) return dir < 0 ? m[m.length - 1] : m[0];
+  }
+  return null;
+}
+
+/** The very first (dir>0) or very last (dir<0) match in the whole pane, ignoring the
+ *  viewport entirely — used by findStep to wrap around once nextMatch runs off the
+ *  document's actual start/end, same as a browser's own Ctrl+F. */
+function firstMatchInDocument(pane, dir, needle) {
+  const turns = pane.querySelectorAll(':scope > .turn');
+  if (dir > 0) {
+    for (const t of turns) {
+      const m = matchesInTurn(t, needle).filter(hasAnyRect);
+      if (m.length) return m[0];
+    }
+    return null;
+  }
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const m = matchesInTurn(turns[i], needle).filter(hasAnyRect);
+    if (m.length) return m[m.length - 1];
+  }
+  return null;
+}
+
+/** Paints (or repaints) the match/active highlights. Safe to call with an empty array to
+ *  clear — the only way to remove a stale highlight when switching tabs or closing the
+ *  bar, since CSS.highlights is keyed by name globally, not by element. `active` (if
+ *  given and not already inside `matches`, e.g. it just scrolled out of the viewport) is
+ *  still painted as the active highlight even though it isn't part of the plain set.
+ *
+ *  The active match is explicitly EXCLUDED from the plain set below, not just added to
+ *  its own on top of it: registering the same Range in two overlapping ::highlight()
+ *  sets leaves which one paints on top up to the browser/engine's own priority rules,
+ *  and WebKitGTK was observed painting the plain "match" color over the "active" one —
+ *  every match looked identical, making Enter/Shift+Enter's effect invisible. Excluding
+ *  it removes the overlap entirely rather than trying to out-rank it. */
+function paintHighlights(matches, active) {
+  if (!HAS_HIGHLIGHT_API) return;   // no highlight support: stepping still works, just unpainted
+  const all = new Highlight();
+  for (const m of matches) {
+    if (active && m.compareBoundaryPoints(Range.START_TO_START, active) === 0) continue;
+    all.add(m);
+  }
+  // CSS.highlights.set() does NOT reliably REPLACE an existing registration under this
+  // WebKitGTK — observed on both sets independently: (1) set() with a zero-range Highlight
+  // over a previously non-empty one left the old ranges visibly painted (a query going
+  // from matches to no-matches, e.g. typing an extra space, left the narrower query's
+  // stale highlight on screen even though #find-count correctly said "Not found"); (2) far
+  // more strikingly, typing "verify" in one continuous burst (no backspace) left an
+  // earlier "ver"-era single-range FIND_ACTIVE_HL highlight painted in the ACTIVE color
+  // alongside the new one — two active-colored matches on screen from one search, not a
+  // plain/active color mismatch. Both are the same underlying failure: set() over an
+  // existing key doesn't evict what was there. CSS.highlights.delete() does not have this
+  // problem (clearHighlights, which has always used delete, has never shown this symptom)
+  // — so unconditionally delete before every set on both keys, not just the empty-match
+  // branch this fix originally only covered. lastMatchHl/lastActiveHl's own .clear() is a
+  // second, independent belt-and-braces measure — see their declaration above.
+  if (lastMatchHl) lastMatchHl.clear();
+  CSS.highlights.delete(FIND_MATCH_HL);
+  if (all.size > 0) { CSS.highlights.set(FIND_MATCH_HL, all); lastMatchHl = all; } else { lastMatchHl = null; }
+  if (lastActiveHl) lastActiveHl.clear();
+  CSS.highlights.delete(FIND_ACTIVE_HL);
+  if (active) {
+    const activeHl = new Highlight(active);
+    CSS.highlights.set(FIND_ACTIVE_HL, activeHl);
+    lastActiveHl = activeHl;
+  } else {
+    lastActiveHl = null;
+  }
+}
+function clearHighlights() {
+  if (!HAS_HIGHLIGHT_API) return;
+  if (lastMatchHl) lastMatchHl.clear();
+  if (lastActiveHl) lastActiveHl.clear();
+  lastMatchHl = null;
+  lastActiveHl = null;
+  CSS.highlights.delete(FIND_MATCH_HL);
+  CSS.highlights.delete(FIND_ACTIVE_HL);
+}
+
+/** Scrolls a match into view. Only handles the scroll itself and the bookkeeping that
+ *  goes with a scroll specifically — goToMatch (this function's only caller) disarms
+ *  followTail unconditionally before deciding whether a scroll is even needed at all,
+ *  since "the user jumped to a match" is what means they left the tail, not "a scroll
+ *  happened to occur"; see goToMatch's own comment for why that distinction mattered.
+ *
+ *  suppressFollowTailUpdate: chat.js's 'scroll' listener normally recomputes followTail
+ *  on every scroll (isNearBottom()), which would immediately overwrite goToMatch's
+ *  explicit false the instant this scroll fires its own 'scroll' event — a plain save/
+ *  restore around the write would race that listener (it could run after the restore and
+ *  clobber followTail right back). Setting this flag first makes the listener skip that
+ *  recompute for exactly this one scroll. Cleared on the next frame, the reliable point
+ *  by which the browser has dispatched the event for this synchronous write.
+ *
+ *  Sets messagesEl.scrollTop directly from the Range's own rect rather than delegating
+ *  to Element.scrollIntoView on some element derived from the Range: a match inside a
+ *  horizontally-scrollable code block (.code-block pre / .a-body pre code, both
+ *  overflow-x: auto) has THAT element as its nearest scrollable ancestor, and
+ *  scrollIntoView is free to satisfy the request by scrolling it instead of messagesEl
+ *  — leaving messagesEl exactly where it was while reporting success. This was the root
+ *  cause of "stuck" navigation into a dense syntax-highlighted JSON block: every step
+ *  correctly advanced to a new, distinct match, but the container that actually needed
+ *  to move never did. Computing scrollTop from getClientRects() bypasses ancestor
+ *  selection entirely — there's only one container being asked to scroll. */
+function scrollToMatch(range) {
+  const rects = range.getClientRects();
+  const r = rects.length ? rects[0] : null;
+  if (!r) return;
+  const box = messagesEl.getBoundingClientRect();
+  suppressFollowTailUpdate = true;
+  messagesEl.scrollTop += (r.top - box.top) - (box.height - r.height) / 2;
+  requestAnimationFrame(() => { suppressFollowTailUpdate = false; });
+}

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -94,11 +94,22 @@ function updateSearchScopeButton() {
   btn.innerHTML = ICONS[SEARCH_SCOPE_ICON[searchScope]];
 }
 
+// Below this, a content scan is skipped — title-only filtering still applies (it's
+// instant, from the already-cached list) but grepping every session's transcript for
+// 1-2 characters is expensive for a query too short to be selective, matching the same
+// gate on Find in Conversation (find.js's FIND_MIN_QUERY_LEN).
+const CONTENT_SEARCH_MIN_QUERY_LEN = 3;
+
 function runContentSearch(query) {
   const myId = ++searchRequestId;
   contentMatches = {};
-  if (!query || searchScope === 'title' || !window._searchSessionContentAsync) {
-    searchInFlight = false; updateSearchBusy(); return;
+  // Every early return here must re-render: the caller (onHistorySearchInput) already
+  // rendered once with the OLD contentMatches before calling this, so skipping the
+  // render below would leave phantom rows on screen (sessions that matched the
+  // previous, longer query's content but neither the new query's title nor anything
+  // else) until the user's next keystroke happened to trigger a real scan.
+  if (!query || query.length < CONTENT_SEARCH_MIN_QUERY_LEN || searchScope === 'title' || !window._searchSessionContentAsync) {
+    searchInFlight = false; updateSearchBusy(); renderHistoryList(); return;
   }
   // Only the sessions the title filter didn't already catch — a title match is
   // shown regardless, so there's no reason to also grep that session's body.
@@ -106,7 +117,7 @@ function runContentSearch(query) {
   const idsToScan = histSessions
     .filter(s => !(s.display || '').toLowerCase().includes(q))
     .map(s => s.sessionId);
-  if (!idsToScan.length) { searchInFlight = false; updateSearchBusy(); return; }
+  if (!idsToScan.length) { searchInFlight = false; updateSearchBusy(); renderHistoryList(); return; }
   searchInFlight = true;
   updateSearchBusy();
   window._searchSessionContentAsync(JSON.stringify(idsToScan), query, String(myId), searchScope === 'own');
@@ -194,7 +205,13 @@ function closeHistoryPanel() {
   const panel = document.getElementById('history-panel');
   if (panel) panel.classList.remove('open');
   if (openMenuEl === panel) { openMenuEl = null; openAnchor = null; }
-  unregisterOverlayCancel();
+  // By identity, not bare: cancelActiveCard (carddock.js) already pops this entry off
+  // the stack itself before calling closeHistoryPanel as entry.fn() — a bare unregister
+  // here would then pop whatever's now on TOP instead (e.g. the find bar, if it was
+  // opened before History and is still up), silently stranding ITS own registration.
+  // Confirmed by repro: Ctrl+F, then History, then two Ctrl+G presses closed History
+  // then did nothing — the find bar's entry had already been eaten by this line.
+  unregisterOverlayCancel(closeHistoryPanel);
 }
 
 /* Called from the native Eclipse view toolbar's "Session history" Action

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/icons.js
@@ -50,7 +50,11 @@ const ICONS = {
      substitution below matches __[A-Z]+__ only, so CHEV_DOWN would never expand. */
   FOLDER: '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>',
   CHEVDOWN: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 5l6 6 6-6M6 12l6 6 6-6"/></svg>',
-  CHEVUP: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 19l6-6 6 6M6 12l6-6 6 6"/></svg>'
+  CHEVUP: '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 19l6-6 6 6M6 12l6-6 6 6"/></svg>',
+  /* Single-chevron prev/next, for the find bar (CHEVUP/CHEVDOWN above are double-chevron,
+     used by the supertabs row). */
+  CHEVRONUP: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 15l6-6 6 6"/></svg>',
+  CHEVRONDOWN: '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg>'
 };
 /* substitute __NAME__ placeholders */
 document.body.innerHTML = document.body.innerHTML.replace(/__([A-Z]+)__/g, (m, k) => ICONS[k] || m);

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/tabs.js
@@ -139,6 +139,9 @@ function switchTab(id) {
     prev.followTail = followTail;
     prev.scrollTop = messagesEl.scrollTop;
   }
+  // Find bar: park the outgoing tab's query/matches/open-state, restore the incoming
+  // tab's — same per-tab-state shape as the draft/scroll position above.
+  if (typeof onFindTabSwitch === 'function') onFindTabSwitch(prev, tabById(id));
   activeId = id;
   tabs.forEach(t => { t.pane.style.display = (t.id === id) ? '' : 'none'; });
   const t = activeTab();

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/ui.js
@@ -9,11 +9,14 @@ function closeMenus() {
   // through here (click-outside, opening a different menu, …), so this is the one
   // place that can defer to closeHistoryPanel's own unregister when it was open.
   //
-  // Guarded by identity, not just "was it open": activeCardCancel is ONE global slot,
-  // and a later overlay (e.g. an in-transcript image's lightbox, registered during the
-  // click's target phase) can install ITS OWN cancel before this listener runs in the
-  // bubble phase — unregistering unconditionally here would wipe that newer
-  // registration and tell Java the wrong overlay just closed.
+  // Removes closeHistoryPanel's entry BY IDENTITY rather than unregistering the top of
+  // carddock.js's cancel stack: a later overlay (e.g. an in-transcript image's lightbox,
+  // registered during the click's target phase) can already be on top by the time this
+  // listener runs in the bubble phase, with history's own entry stranded underneath it —
+  // a bare unregister here would pop that NEWER overlay instead and tell Java the wrong
+  // thing closed, while leaving history's dead entry buried in the stack to consume a
+  // future dismiss-key press for nothing. Passing the fn explicitly finds and removes
+  // history's entry specifically, wherever it currently sits.
   const hist = document.getElementById('history-panel');
   const histWasOpen = hist && hist.classList.contains('open');
   document.querySelectorAll('.menu.open').forEach(m => m.classList.remove('open'));
@@ -21,7 +24,7 @@ function closeMenus() {
   // per-message badges are pinned visible while their menu is up — unpin them
   document.querySelectorAll('.msg-actions.open').forEach(w => w.classList.remove('open'));
   openMenuEl = null; openAnchor = null;
-  if (histWasOpen && activeCardCancel === closeHistoryPanel) unregisterOverlayCancel();
+  if (histWasOpen) unregisterOverlayCancel(closeHistoryPanel);
 }
 
 /* Position a menu relative to its trigger button, so it stays glued to that element

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
@@ -37,6 +37,54 @@
   background: var(--menu-bg); color: var(--fg-soft); border: 1px solid var(--border);
   box-shadow: 0 2px 6px rgba(0,0,0,.3); }
 #jump-to-latest.show { display: flex; }
+
+/* Find-in-conversation bar. Floats over the top-LEFT corner of the transcript, same
+   reasoning as #jump-to-latest above: a child of #messages (the scroll container)
+   would scroll away with the content, so this is a sibling positioned against
+   #zoom-root instead (layout.css — any non-static position establishes a containing
+   block, absolute included, so #zoom-root itself doesn't need position:relative).
+   Deliberately on the LEFT, not the right: History (and every other .menu) hangs off
+   an Eclipse view-toolbar button, and Eclipse right-aligns view-toolbar actions — so
+   the right corner is always contested ground and the left corner never is. An
+   earlier version lived top-right and needed a z-index dance (an .above-menu class,
+   toggled on whichever of find/History opened more recently) just to stay visible
+   when the two happened to be open at once; moving the corner removed the conflict
+   at the source instead of arbitrating it.
+   `top` below is only a pre-JS fallback (never actually visible while display:none) —
+   openFindBar (find.js) overrides it with messagesEl.offsetTop + 8 every time the bar
+   opens. #zoom-root's top edge is the page's own top, ABOVE #supertab-row/#cwd-row/
+   #toolbar/#update-banner, so a fixed value here floated the bar over whichever of
+   those chrome rows was visible instead of over the transcript — confirmed by a
+   screenshot showing it sitting on top of the tab strip. */
+#find-bar { display: none; position: absolute; top: 8px; left: 22px; z-index: 6;
+  align-items: center; gap: 2px; padding: 4px 6px; border-radius: 8px;
+  background: var(--menu-bg); border: 1px solid var(--border); box-shadow: 0 2px 8px rgba(0,0,0,.3); }
+#find-bar.open { display: flex; }
+#find-bar input { width: 180px; background: var(--bg-code); border: 1px solid var(--border);
+  border-radius: 5px; padding: 4px 7px; color: var(--fg); font-size: 12px; outline: none; }
+#find-bar input:focus { border-color: var(--accent); }
+#find-count { color: var(--fg-faint); font-size: 11px; min-width: 52px; text-align: center; flex-shrink: 0; }
+#find-bar .find-action { display: flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 5px; color: var(--fg-faint); cursor: pointer; flex-shrink: 0; }
+#find-bar .find-action:hover { color: var(--fg); background: var(--bg-hover); }
+
+/* CSS Custom Highlight API — find.js paints Range objects into these without touching
+   the DOM (no wrapping <mark> elements to insert/remove on every keystroke). The active
+   match is never also a member of cc-find-match (find.js's paintHighlights explicitly
+   excludes it) — the two sets never overlap the same Range, by design: WebKitGTK does
+   not reliably let a later/higher-priority ::highlight() rule win over an earlier one on
+   overlapping Ranges, so the plain match color was painting over the active one, making
+   every match look identical and Enter/Shift+Enter's effect invisible. */
+/* ::highlight() only accepts a restricted property set (color, background-color,
+   text-decoration/shadow, -webkit-text-stroke/fill) — the `background` SHORTHAND also
+   sets background-image/position/repeat, which aren't in that set, so the whole
+   declaration would be dropped silently (matches found and navigable, nothing visibly
+   painted). Longhand only. */
+::highlight(cc-find-match) { background-color: var(--find-match-bg); }
+/* Also changes `color`, not just a stronger background alpha: against a dense field of
+   plain matches (e.g. a JSON blob where "descr" hits dozens of times), a same-hue
+   background step alone was too subtle to pick the active one out at a glance. */
+::highlight(cc-find-active) { background-color: var(--find-active-bg); color: var(--on-accent); }
 #jump-to-latest:hover { color: var(--fg); border-color: var(--accent-dim); }
 
 .turn { position: relative; margin: 10px 0; }

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/tokens.css
@@ -66,6 +66,8 @@
   --track: #444;              /* slider track */
   --knob: #ddd;               /* slider knob */
   --hover-veil: rgba(255,255,255,.08);  /* subtle hover on dark surfaces */
+  --find-match-bg: rgba(255,213,0,.35);   /* find-in-conversation: all matches */
+  --find-active-bg: rgba(255,140,0,.65);  /* find-in-conversation: current match */
   /* syntax */
   --kw: #569cd6; --type: #4ec9b0; --str: #ce9178; --com: #6a9955; --fn: #dcdcaa; --num: #b5cea8;
 }
@@ -140,6 +142,8 @@
   --track: #cfcfcf;
   --knob: #555;
   --hover-veil: rgba(0,0,0,.06);
+  --find-match-bg: rgba(255,196,0,.45);   /* find-in-conversation: all matches */
+  --find-active-bg: rgba(255,140,0,.55);  /* find-in-conversation: current match */
   /* syntax — light editor palette (VSCode Light+) */
   --kw: #0000ff; --type: #267f99; --str: #a31515; --com: #008000; --fn: #795e26; --num: #098658;
 }

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -143,6 +143,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     @SuppressWarnings("unused") private BrowserFunction decideFn;
     @SuppressWarnings("unused") private BrowserFunction answerQuestionFn;
     @SuppressWarnings("unused") private BrowserFunction overlayOpenFn;
+    @SuppressWarnings("unused") private BrowserFunction debugLogFn;
     @SuppressWarnings("unused") private BrowserFunction modelConfigFn;
     @SuppressWarnings("unused") private BrowserFunction accountInfoFn;
     @SuppressWarnings("unused") private BrowserFunction defaultRootFn;
@@ -166,6 +167,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     @SuppressWarnings("unused") private BrowserFunction advisorGetFn;
     @SuppressWarnings("unused") private BrowserFunction advisorSetFn;
     @SuppressWarnings("unused") private BrowserFunction openExternalFn;
+    @SuppressWarnings("unused") private BrowserFunction openFileInEditorFn;
     @SuppressWarnings("unused") private BrowserFunction clipGetFn;
     @SuppressWarnings("unused") private BrowserFunction clipSetFn;
     @SuppressWarnings("unused") private BrowserFunction clipImagesFn;
@@ -174,7 +176,6 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     private final java.util.concurrent.ConcurrentLinkedQueue<Map<String, String>> fetchedImages =
             new java.util.concurrent.ConcurrentLinkedQueue<>();
     @SuppressWarnings("unused") private BrowserFunction editOpsReadyFn;
-    @SuppressWarnings("unused") private BrowserFunction debugLogFn;
     /** Set by the page once the __cc* editing entry points exist — see registerEditHandlers. */
     private volatile boolean editOpsReady = false;
 
@@ -259,6 +260,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         root = parent;
         browser = new Browser(parent, SWT.NONE);
         browser.setLayoutData(new org.eclipse.swt.layout.GridData(SWT.FILL, SWT.FILL, true, true));
+        hookViewFocusContext();
 
         // Extract HWND so WebView2 keyboard input can be activated.
         try {
@@ -754,6 +756,15 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // the session reloaded from history (issue #96). JS hands links here instead.
         openExternalFn = new SimpleFunction(browser, "_openExternal", a -> {
             if (a.length > 0 && a[0] instanceof String url) openExternal(url);
+            return null;
+        });
+        // A tool line's file path (Read/Edit/Write/…) — root is the OWNING tab's working
+        // directory, sent by the page since a relative path resolves against whichever
+        // conversation the line belongs to, not necessarily the one on screen right now.
+        openFileInEditorFn = new SimpleFunction(browser, "_openFileInEditor", a -> {
+            String path = a.length > 0 && a[0] instanceof String s ? s : null;
+            String root = a.length > 1 && a[1] instanceof String s ? s : null;
+            if (path != null) openFileInEditor(path, root);
             return null;
         });
 
@@ -2210,6 +2221,43 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         }
     }
 
+    /**
+     * Opens a tool line's file path (Read/Edit/Write/…) in an Eclipse editor. {@code path}
+     * is resolved against {@code root} (the OWNING tab's working directory) only when it
+     * isn't already absolute — the CLI's tool inputs are normally absolute already, so this
+     * is a fallback rather than the common case. Silently does nothing for a path that
+     * doesn't resolve to an existing file: a stale reference (later deleted/renamed) is a
+     * routine, expected outcome of clicking something from earlier in a conversation, not
+     * an error worth surfacing.
+     */
+    private static void openFileInEditor(String path, String root) {
+        // This callback runs synchronously inside SimpleFunction, i.e. inside WebKitGTK's
+        // JS execution — which runs inside this process's single GTK main loop (SWT's
+        // Browser on Linux is in-process, not a separate process like Windows' WebView2).
+        // openEditorOnFileStore pumps its own nested event processing (workspace
+        // notifications, SWT widget creation, editor-registry lookups), and doing that
+        // while already inside a browser callback stalled the entire IDE for up to a
+        // minute — confirmed by instrumentation, fixed by deferring the actual open to a
+        // fresh UI-thread dispatch cycle instead of running it inline.
+        Display.getDefault().asyncExec(() -> {
+            try {
+                Path p = Path.of(path);
+                if (!p.isAbsolute() && root != null && !root.isBlank()) {
+                    p = Path.of(root).resolve(path);
+                }
+                if (!Files.isRegularFile(p)) return;
+                org.eclipse.ui.IWorkbenchPage page = com.anthropic.claudecode.eclipse.editor.UiHelper.getActivePage();
+                if (page == null) return;
+                org.eclipse.core.filesystem.IFileStore fileStore =
+                        org.eclipse.core.filesystem.EFS.getLocalFileSystem().getStore(p.toUri());
+                org.eclipse.ui.ide.IDE.openEditorOnFileStore(page, fileStore);
+            } catch (Exception ignored) {
+                // Malformed path, no active page, or the open itself failed — the click
+                // just does nothing rather than popping an error over the conversation.
+            }
+        });
+    }
+
     /** Make sure the Rust MCP server (used by chat for editor tools) is up. */
     private void ensureServerAsync() {
         Thread t = new Thread(() -> {
@@ -2898,18 +2946,84 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         return "";
     }
 
+    private static int lastDismissEventTime = -1;
+
     /**
      * Invoked by {@link com.anthropic.claudecode.eclipse.ui.handlers.DismissCardHandler}
      * when the bound key is pressed. Routes to the page's own cancel path so the keyboard
      * and in-page routes stay identical.
      */
-    public static void dismissActiveCard() {
+    public static void dismissActiveCard(int eventTime) {
+        // Eclipse was confirmed (via logging, since removed) to dispatch this command
+        // multiple times for one physical keypress — a single Ctrl+G was observed popping
+        // TWO entries off the JS-side cancel stack (find AND history). Dedup on the OS-level
+        // event timestamp (Event.time — identical across redeliveries of one keypress,
+        // distinct across separate presses) rather than a wall-clock time window, which
+        // would need guessing at how many redeliveries can occur.
+        if (eventTime != -1 && eventTime == lastDismissEventTime) return;
+        lastDismissEventTime = eventTime;
         ClaudeGuiView view = active;
         if (view == null || view.browser == null || view.browser.isDisposed()
                 || !view.pageLoaded) {
             return;
         }
         view.browser.execute("window.cancelActiveCard && window.cancelActiveCard()");
+    }
+
+    // ── Find-in-conversation key binding (Ctrl+F by default, rebindable) ────────────
+
+    private static final String VIEW_FOCUS_CONTEXT_ID =
+            "com.anthropic.claudecode.eclipse.contexts.guiViewFocus";
+
+    private org.eclipse.ui.contexts.IContextActivation viewFocusActivation;
+
+    /**
+     * Activates {@link #VIEW_FOCUS_CONTEXT_ID} while this view's browser has keyboard
+     * focus, and deactivates it on {@code focusLost} — the same activate/deactivate shape
+     * as {@link #cardOpened()}/{@link #cardClosed()}, just keyed to widget focus instead of
+     * card state. Unlike cardOpen (deliberately global — a card blocks the whole workflow
+     * regardless of which part has focus), Ctrl+F must NOT be global: without this scoping
+     * it would shadow Ctrl+F in every editor and view in the IDE.
+     */
+    private void hookViewFocusContext() {
+        browser.addFocusListener(new org.eclipse.swt.events.FocusAdapter() {
+            @Override
+            public void focusGained(org.eclipse.swt.events.FocusEvent e) {
+                if (viewFocusActivation != null) return;
+                org.eclipse.ui.contexts.IContextService svc = contextService();
+                if (svc != null) viewFocusActivation = svc.activateContext(VIEW_FOCUS_CONTEXT_ID);
+            }
+            @Override
+            public void focusLost(org.eclipse.swt.events.FocusEvent e) {
+                if (viewFocusActivation == null) return;
+                org.eclipse.ui.contexts.IContextService svc = contextService();
+                if (svc != null) {
+                    try { svc.deactivateContext(viewFocusActivation); } catch (Exception ignored) {}
+                }
+                viewFocusActivation = null;
+            }
+        });
+    }
+
+    private static int lastToggleFindEventTime = -1;
+
+    /**
+     * Invoked by {@link com.anthropic.claudecode.eclipse.ui.handlers.FindInConversationHandler}
+     * when the bound key is pressed. Routes to the page's own toggle so the keyboard and any
+     * future in-page trigger stay identical.
+     */
+    public static void toggleFindInConversation(int eventTime) {
+        // See dismissActiveCard's matching comment — a single Ctrl+F press was confirmed
+        // (via logging, since removed) to produce THREE Java-side invocations from Eclipse
+        // itself. Same Event.time dedup.
+        if (eventTime != -1 && eventTime == lastToggleFindEventTime) return;
+        lastToggleFindEventTime = eventTime;
+        ClaudeGuiView view = active;
+        if (view == null || view.browser == null || view.browser.isDisposed()
+                || !view.pageLoaded) {
+            return;
+        }
+        view.browser.execute("window.toggleFindBar && window.toggleFindBar()");
     }
 
     /** Pushes the current cancel-key label to the page. UI thread; call before raising a card. */

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/FindInConversationHandler.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/handlers/FindInConversationHandler.java
@@ -6,23 +6,18 @@ import org.eclipse.core.commands.ExecutionEvent;
 import com.anthropic.claudecode.eclipse.ui.ClaudeGuiView;
 
 /**
- * Dismisses the permission / question / diff-review card currently awaiting an answer.
+ * Toggles the find bar for the active Claude Code conversation tab.
  *
- * <p>Bound per scheme in {@code plugin.xml} — Esc under the default scheme, Ctrl+G under
- * Emacs, where Esc is a multi-stroke prefix and never reaches the page. Both bindings are
- * scoped to the {@code contexts.cardOpen} context, which is only active while a card is up,
- * so neither key is taken away from the rest of the IDE.
- *
- * <p>The work is deliberately delegated to the page rather than reimplemented here: the
- * card's own JS {@code cancel()} already answers the CLI, resolves the step dot and tears
- * the card down. Going through it means the keyboard path and the in-page Esc path cannot
- * drift apart, and the existing {@code resolved} guard makes a double-fire a no-op.
+ * <p>Bound to Ctrl+F by default (rebindable under Preferences &gt; Keys), scoped to the
+ * {@code contexts.guiViewFocus} context — active only while the view's browser control has
+ * keyboard focus, so the binding never shadows Ctrl+F elsewhere in the IDE (text editors'
+ * own Find/Replace included).
  */
-public class DismissCardHandler extends AbstractHandler {
+public class FindInConversationHandler extends AbstractHandler {
 
     @Override
     public Object execute(ExecutionEvent event) {
-        ClaudeGuiView.dismissActiveCard(eventTime(event));
+        ClaudeGuiView.toggleFindInConversation(eventTime(event));
         return null;
     }
 


### PR DESCRIPTION
Ctrl+F opens a find bar over the active tab's own conversation, so you can search within one long conversation instead of scrolling to look for something.

Enter/Shift+Enter jump to the next/previous match anywhere in the conversation. Matches near what's currently on screen are found instantly as you type.

The find bar and the History panel can now be open simultaneously and each still closes correctly with Escape — previously, whichever opened first could lose its own close binding to the other.

Also fixes Escape occasionally taking two presses to close something, an intermittent issue from Eclipse redelivering one keypress to the handler more than once.