### PR TITLE
Make a tool line's file path open that file in an editor

### DIFF
--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/chat.js
@@ -284,6 +284,9 @@ function toolLabel(name) {
  * @param {string} name  raw tool name (mcp__… prefixes get stripped for display)
  * @param {Object} input tool_use input (file_path/command/pattern/… picked for detail)
  * @param {"done"|"interrupted"|undefined} [status] reload path only — colors the dot
+ * @param {string} [errorText] reload path only
+ * @param {string} [root] the OWNING conversation's working directory, for resolving a
+ *   relative file_path when the line is clicked — see .tpath's onclick below.
  * @returns {HTMLElement} the .tool-line item
  */
 /* Outcome text for an ExitPlanMode line. Shared by the LIVE decision path
@@ -304,7 +307,7 @@ function setToolError(line, text) {
   if (!sub) { sub = document.createElement('div'); sub.className = 'tool-sub err'; line.appendChild(sub); }
   sub.textContent = '⚠ ' + text;
 }
-function makeToolLine(name, input, status, errorText) {
+function makeToolLine(name, input, status, errorText, root) {
   input = input || {};
   const path = input.file_path || input.path || input.notebook_path || '';
   const detail = path || input.command || input.pattern || input.query || input.url || input.prompt || '';
@@ -312,7 +315,21 @@ function makeToolLine(name, input, status, errorText) {
   const dotClass = status === 'done' ? 'dot done' : status === 'interrupted' ? 'dot red' : 'dot';
   line.innerHTML = '<span class="' + dotClass + '"></span><span class="tname"></span> <span class="tpath"></span>';
   line.querySelector('.tname').textContent = toolLabel(name);   // generic label, not the raw name
-  line.querySelector('.tpath').textContent = detail;
+  const tpathEl = line.querySelector('.tpath');
+  tpathEl.textContent = detail;
+  // Only an actual file path is clickable — never the bash/grep/url/prompt fallbacks
+  // `detail` also covers. Silently a no-op if the path turns out stale (deleted,
+  // renamed) or unresolvable; see ClaudeGuiView#openFileInEditor.
+  if (path && window._openFileInEditor) {
+    tpathEl.classList.add('clickable');
+    tpathEl.title = 'Open in editor';
+    // No stopPropagation: unlike msgactions.js's icons (which sit inside a clickable
+    // .item), no ancestor of .tool-line has its own onclick, and this transcript sits
+    // inside the same page as menus tracked by openMenuEl — stopping propagation here
+    // would silently stop clicking a path from also closing an open menu via ui.js's
+    // click-outside handler, same class of bug as cycleSearchScope's innerHTML swap.
+    tpathEl.onclick = () => window._openFileInEditor(path, root || rootPathOf(activeTab()));
+  }
   const diff = buildToolDiff(name, input);
   if (diff) {
     const sub = document.createElement('div'); sub.className = 'tool-sub'; sub.textContent = diff.summary;
@@ -337,7 +354,9 @@ function addToolLine(payload) {
   if (!ensureTurn()) return;
   markToolsDone(curTurn);   // a new tool starting means the previous one finished → green
   let info; try { info = JSON.parse(payload); } catch (e) { info = { name: payload, input: {} }; }
-  const line = makeToolLine(info.name || 'tool', info.input || {});
+  // rtab, not activeTab(): a background tab's own stream must resolve a relative
+  // file_path against ITS OWN root, not whichever tab happens to be on screen.
+  const line = makeToolLine(info.name || 'tool', info.input || {}, undefined, undefined, rootPathOf(rtab));
   // The tool_use id, so this line can be found again when its result lands. An
   // older core sends no id — the line then just keeps the inferred green dot.
   if (info.id) line.dataset.tuid = info.id;

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/scripts/history.js
@@ -550,7 +550,7 @@ function loadHistory(id, title, targetTab) {
       appendThinkStatic(assistantTurn(), it.text || '');
     } else if (ty === 'tool') {
       flushCompact();
-      assistantTurn().appendChild(makeToolLine(it.name || 'tool', it.input || {}, it.status, it.errorText));
+      assistantTurn().appendChild(makeToolLine(it.name || 'tool', it.input || {}, it.status, it.errorText, rootPathOf(t)));
     } else { // text
       flushCompact();
       appendTextStatic(assistantTurn(), it.text || it.content || '');

--- a/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
+++ b/com.anthropic.claudecode.eclipse/resources/claudegui/styles/chat.css
@@ -186,6 +186,8 @@
 .tool-line { font-size: 12.5px; }
 .tool-line .tname { font-weight: 600; color: var(--fg); }
 .tool-line .tpath { color: var(--fg-dim); word-break: break-all; }
+.tool-line .tpath.clickable { cursor: pointer; }
+.tool-line .tpath.clickable:hover { color: var(--fg); text-decoration: underline; }
 .tool-sub { font-size: 11.5px; color: var(--fg-faint); margin-top: 2px; margin-bottom: 6px; }
 /* Why a tool failed. Clamped to ONE line here as well as in the summariser: real
    results run to 100+ lines, and the transcript stays scannable only if a failure

--- a/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
+++ b/com.anthropic.claudecode.eclipse/src/com/anthropic/claudecode/eclipse/ui/ClaudeGuiView.java
@@ -166,6 +166,7 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
     @SuppressWarnings("unused") private BrowserFunction advisorGetFn;
     @SuppressWarnings("unused") private BrowserFunction advisorSetFn;
     @SuppressWarnings("unused") private BrowserFunction openExternalFn;
+    @SuppressWarnings("unused") private BrowserFunction openFileInEditorFn;
     @SuppressWarnings("unused") private BrowserFunction clipGetFn;
     @SuppressWarnings("unused") private BrowserFunction clipSetFn;
     @SuppressWarnings("unused") private BrowserFunction clipImagesFn;
@@ -754,6 +755,15 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
         // the session reloaded from history (issue #96). JS hands links here instead.
         openExternalFn = new SimpleFunction(browser, "_openExternal", a -> {
             if (a.length > 0 && a[0] instanceof String url) openExternal(url);
+            return null;
+        });
+        // A tool line's file path (Read/Edit/Write/…) — root is the OWNING tab's working
+        // directory, sent by the page since a relative path resolves against whichever
+        // conversation the line belongs to, not necessarily the one on screen right now.
+        openFileInEditorFn = new SimpleFunction(browser, "_openFileInEditor", a -> {
+            String path = a.length > 0 && a[0] instanceof String s ? s : null;
+            String root = a.length > 1 && a[1] instanceof String s ? s : null;
+            if (path != null) openFileInEditor(path, root);
             return null;
         });
 
@@ -2208,6 +2218,43 @@ public class ClaudeGuiView extends ViewPart implements IShowInTarget {
             // No external browser configured, or the URL isn't RFC-clean — let the OS pick.
             try { org.eclipse.swt.program.Program.launch(url); } catch (Exception ignored) {}
         }
+    }
+
+    /**
+     * Opens a tool line's file path (Read/Edit/Write/…) in an Eclipse editor. {@code path}
+     * is resolved against {@code root} (the OWNING tab's working directory) only when it
+     * isn't already absolute — the CLI's tool inputs are normally absolute already, so this
+     * is a fallback rather than the common case. Silently does nothing for a path that
+     * doesn't resolve to an existing file: a stale reference (later deleted/renamed) is a
+     * routine, expected outcome of clicking something from earlier in a conversation, not
+     * an error worth surfacing.
+     */
+    private static void openFileInEditor(String path, String root) {
+        // This callback runs synchronously inside SimpleFunction, i.e. inside WebKitGTK's
+        // JS execution — which runs inside this process's single GTK main loop (SWT's
+        // Browser on Linux is in-process, not a separate process like Windows' WebView2).
+        // openEditorOnFileStore pumps its own nested event processing (workspace
+        // notifications, SWT widget creation, editor-registry lookups), and doing that
+        // while already inside a browser callback stalled the entire IDE for up to a
+        // minute — confirmed by instrumentation, fixed by deferring the actual open to a
+        // fresh UI-thread dispatch cycle instead of running it inline.
+        Display.getDefault().asyncExec(() -> {
+            try {
+                Path p = Path.of(path);
+                if (!p.isAbsolute() && root != null && !root.isBlank()) {
+                    p = Path.of(root).resolve(path);
+                }
+                if (!Files.isRegularFile(p)) return;
+                org.eclipse.ui.IWorkbenchPage page = com.anthropic.claudecode.eclipse.editor.UiHelper.getActivePage();
+                if (page == null) return;
+                org.eclipse.core.filesystem.IFileStore fileStore =
+                        org.eclipse.core.filesystem.EFS.getLocalFileSystem().getStore(p.toUri());
+                org.eclipse.ui.ide.IDE.openEditorOnFileStore(page, fileStore);
+            } catch (Exception ignored) {
+                // Malformed path, no active page, or the open itself failed — the click
+                // just does nothing rather than popping an error over the conversation.
+            }
+        });
     }
 
     /** Make sure the Rust MCP server (used by chat for editor tools) is up. */


### PR DESCRIPTION
A tool-use line that names a file (Read, Edit, a grep match) now opens that file in an editor when clicked, the same as clicking a file link in the conversation itself.